### PR TITLE
Adding equations to the rewrite rules

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -49,7 +49,7 @@ let check_constant_declaration env opac kn cb opacify =
   let ty = cb.const_type in
   let _ = infer_type env ty in
   let body, env = match cb.const_body with
-    | Undef _ | Primitive _ -> None, env
+    | Undef _ | Primitive _ | Symbol _ -> None, env
     | Def c -> Some c, env
     | OpaqueDef o ->
       let c, u = !indirect_accessor o in

--- a/clib/cArray.mli
+++ b/clib/cArray.mli
@@ -38,6 +38,10 @@ sig
 
   val findi : (int -> 'a -> bool) -> 'a array -> int option
 
+  val find2_map : ('a -> 'b -> 'c option) -> 'a array -> 'b array -> 'c option
+  (** First result which is not None, or None;
+      [Failure "Array.find2_map"] if the arrays don't have the same length *)
+
   val hd : 'a array -> 'a
   (** First element of an array, or [Failure "Array.hd"] if empty. *)
 
@@ -81,6 +85,9 @@ sig
       Raise [Failure "Array.chop"] if [i] is not a valid index. *)
 
   val split : ('a * 'b) array -> 'a array * 'b array
+  val split3 : ('a * 'b * 'c) array -> 'a array * 'b array * 'c array
+  val split4 : ('a * 'b * 'c * 'd) array -> 'a array * 'b array * 'c array * 'd array
+  val transpose : 'a array array -> 'a array array
 
   val map2_i : (int -> 'a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
   val map3 :
@@ -103,6 +110,9 @@ sig
 
   val fold_right_map : ('a -> 'c -> 'b * 'c) -> 'a array -> 'c -> 'b array * 'c
   (** Same, folding on the right *)
+
+  val fold_left_map_i : (int -> 'a -> 'b -> 'a * 'c) -> 'a -> 'b array -> 'a * 'c array
+  (** Same than [fold_left_map] but passing the index of the array *)
 
   val fold_left2_map : ('a -> 'b -> 'c -> 'a * 'd) -> 'a -> 'b array -> 'c array -> 'a * 'd array
   (** Same with two arrays, folding on the left; see also [Smart.fold_left2_map] *)

--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -53,6 +53,7 @@ type assumption_object_kind = Definitional | Logical | Conjectural | Context
 
 type logical_kind =
   | IsPrimitive
+  | IsSymbol
   | IsAssumption of assumption_object_kind
   | IsDefinition of definition_object_kind
   | IsProof of theorem_kind

--- a/interp/decls.mli
+++ b/interp/decls.mli
@@ -50,6 +50,7 @@ type assumption_object_kind = Definitional | Logical | Conjectural | Context
 
 type logical_kind =
   | IsPrimitive
+  | IsSymbol
   | IsAssumption of assumption_object_kind
   | IsDefinition of definition_object_kind
   | IsProof of theorem_kind

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -110,6 +110,7 @@ let type_of_logical_kind = function
       | Proposition
       | Corollary -> "thm")
   | IsPrimitive -> "prim"
+  | IsSymbol -> "symb"
 
 
 (** Data associated to global parameters and constants *)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1587,7 +1587,7 @@ and case_inversion info tab ci u params indices v =
     then Some v else None
 
 and match_arg_pattern info tab p t =
-  match [@ocaml.warning "-4"] p, (fapp_stack (knh info t [])).term with
+  match [@ocaml.warning "-4"] p, t.term with
   | APHole, _ -> [t]
   | APHoleIgnored, _ -> []
   | APInd ind, FInd (ind', _) ->
@@ -1602,18 +1602,18 @@ and match_arg_pattern info tab p t =
       let np = Array.length pargs in
       let na = Array.length args in
       if np == na then
-        let fss = Array.map2 (match_arg_pattern info tab) pargs args in
-        let fs = match_arg_pattern info tab pf f in
+        let fss = Array.map2 (hard_match_arg_pattern info tab) pargs args in
+        let fs = hard_match_arg_pattern info tab pf f in
         fs @ List.concat (Array.to_list fss)
       else if np < na then (* more real arguments *)
         let remargs, usedargs = Array.chop (na - np) args in
-        let fss = Array.map2 (match_arg_pattern info tab) pargs usedargs in
-        let fs = match_arg_pattern info tab pf {mark = f.mark; term=FApp(f, remargs)} in
+        let fss = Array.map2 (hard_match_arg_pattern info tab) pargs usedargs in
+        let fs = hard_match_arg_pattern info tab pf {mark = f.mark; term=FApp(f, remargs)} in
         fs @ List.concat (Array.to_list fss)
       else (* more pattern arguments *)
         let rempargs, usedpargs = Array.chop (np - na) pargs in
-        let fss = Array.map2 (match_arg_pattern info tab) usedpargs args in
-        let fs = match_arg_pattern info tab (APApp (pf, rempargs)) f in
+        let fss = Array.map2 (hard_match_arg_pattern info tab) usedpargs args in
+        let fs = hard_match_arg_pattern info tab (APApp (pf, rempargs)) f in
         fs @ List.concat (Array.to_list fss)
   | _ -> raise PatternFailure
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1494,10 +1494,10 @@ let rec apply_rule info tab p m stk fs =
       let args, stk = get_args_complete (Array.length pargs) stk in
       let fss = Array.map2 match_arg_pattern pargs args in
       apply_rule info tab pf m stk (fs @ List.concat (Array.to_list fss))
-  | Rewrite_rule.PCase (ci, pret, pc, pbrs) ->
+  | Rewrite_rule.PCase (ind, pret, pc, pbrs) ->
       (match [@ocaml.warning "-4"] strip_update_shift_app m stk with
-      | _depth, _args, ZcaseT (ci', _, _, ret, brs, _e) :: stk ->
-        if not @@ Ind.CanOrd.equal ci.Rewrite_rule.ci_ind ci'.ci_ind then raise PatternFailure;
+      | _depth, _args, ZcaseT (ci, _, _, ret, brs, _e) :: stk ->
+        if not @@ Ind.CanOrd.equal ind ci.ci_ind then raise PatternFailure;
         let fsret = match_arg_pattern pret (inject (snd ret)) in
         let fsbrs = Array.map2 (fun a (_, b) -> match_arg_pattern a (inject b)) pbrs brs in
         apply_rule info tab pc m stk (fs @ fsret @ List.concat (Array.to_list fsbrs))

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1859,11 +1859,12 @@ let unfold_ref_with_args infos tab fl v =
     Some (a, (Zupdate a::(Zprimitive(op,c,rargs,nargs)::v)))
   | Rules r ->
     let _, fus = match fl with ConstKey c -> c | RelKey _ | VarKey _ -> assert false in
-      begin try
-        let rhs, fs, v = apply_rules infos tab r v in
-        let subst = List.fold_right subs_cons fs (subs_id 0) in
-        let m' = mk_clos (subst, fus) rhs in
-        Some (m', v)
-      with PatternFailure -> None
+    begin try
+      (* not sure about calling reduction here and about dropping the transparent state *)
+      let rhs, fs, v = apply_rules (infos_with_reds infos all) tab r v in
+      let subst = List.fold_right subs_cons fs (subs_id 0) in
+      let m' = mk_clos (subst, fus) rhs in
+      Some (m', v)
+    with PatternFailure -> None
     end
   | Undef | Primitive _ -> None

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -254,6 +254,8 @@ open Declarations
 type 'constr partial_subst = {
   subst: 'constr list;
   usubst: Univ.Level.t list;
+  hole_index: int;
+  lhs_eqs: int Int.Map.t;
   rhs: constr;
 }
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -251,7 +251,8 @@ val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit
   i This is for lazy debug *)
 
 val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
-val hard_match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
+val match_rigid_arg_pattern : clos_infos -> clos_tab -> Declarations.rigid_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
+val match_rigid_arg_pattern_twice : clos_infos -> clos_tab -> Declarations.rigid_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
 val apply_rule : clos_infos -> clos_tab -> fconstr -> fconstr list * Univ.Level.t list -> Declarations.pattern_elimination list -> stack -> (fconstr list * Univ.Level.t list) * stack_member list
 val apply_rules : clos_infos -> clos_tab -> fconstr -> Univ.Instance.t -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * Univ.Level.t list * stack_member list
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -250,6 +250,13 @@ val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit
 (***********************************************************************
   i This is for lazy debug *)
 
+type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PECase of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array | PEProj of Projection.t
+
+val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
+val match_arg_pattern' : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
+val apply_rule : clos_infos -> clos_tab -> fconstr list -> pattern_elimination list -> stack -> fconstr list * stack_member list
+val apply_rules : clos_infos -> clos_tab -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * stack_member list
+
 val lift_fconstr      : int -> fconstr -> fconstr
 val lift_fconstr_vect : int -> fconstr array -> fconstr array
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -275,7 +275,7 @@ type ('constr, 'stack) state =
   | LocStart of { elims: pattern_elimination list status array; head: 'constr; stack: 'stack; next: ('constr, 'stack) state_next }
   | LocArg of { patterns: pattern_argument status array; arg: 'constr; next: ('constr, 'stack) state }
 
-and ('constr, 'stack) state_next = (('constr, 'stack) state, 'constr * 'stack) next
+and ('constr, 'stack) state_next = (('constr, 'stack) state, bool * 'constr * 'stack) next
 
 
 type ('constr, 'stack) resume_state =

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -273,13 +273,13 @@ type (_, _) escape =
 
 type ('constr, 'stack) state =
   | LocStart of { elims: pattern_elimination list status array; head: 'constr; stack: 'stack; next: ('constr, 'stack) state_next }
-  | LocArg of { patterns: rewrite_arg_pattern status array; arg: 'constr; next: ('constr, 'stack) state }
+  | LocArg of { patterns: pattern_argument status array; arg: 'constr; next: ('constr, 'stack) state }
 
 and ('constr, 'stack) state_next = (('constr, 'stack) state, 'constr * 'stack) next
 
 
 type ('constr, 'stack) resume_state =
-  | Resume of { states: 'constr subst_status array; patterns: (head_pattern * pattern_elimination list) status array; next: ('constr, 'stack) state }
+  | Resume of { states: 'constr subst_status array; patterns: head_elimination status array; next: ('constr, 'stack) state }
 
 type ('constr, 'stack, _) depth =
   | Nil: ('constr * 'stack, 'ret) escape -> ('constr, 'stack, 'ret) depth
@@ -287,8 +287,8 @@ type ('constr, 'stack, _) depth =
 
 val match_main : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> fconstr subst_status array -> (fconstr, stack) state -> 'a
 val match_elim : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> (fconstr, stack) state_next -> fconstr subst_status array -> pattern_elimination list status array -> fconstr -> stack -> 'a
-val match_arg  : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> (fconstr, stack) state      -> fconstr subst_status array -> rewrite_arg_pattern status array -> fconstr -> 'a
-val match_head : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> (fconstr, stack) state      -> fconstr subst_status array -> (head_pattern * pattern_elimination list) status array -> fconstr -> stack -> 'a
+val match_arg  : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> (fconstr, stack) state      -> fconstr subst_status array -> pattern_argument status array -> fconstr -> 'a
+val match_head : clos_infos -> clos_tab -> pat_state:(fconstr, stack, 'a) depth -> (fconstr, stack) state      -> fconstr subst_status array -> head_elimination status array -> fconstr -> stack -> 'a
 
 val lift_fconstr      : int -> fconstr -> fconstr
 val lift_fconstr_vect : int -> fconstr array -> fconstr array

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -254,8 +254,8 @@ type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PEC
 
 val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
 val match_arg_pattern' : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
-val apply_rule : clos_infos -> clos_tab -> fconstr list -> pattern_elimination list -> stack -> fconstr list * stack_member list
-val apply_rules : clos_infos -> clos_tab -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * stack_member list
+val apply_rule : clos_infos -> clos_tab -> fconstr -> fconstr list -> pattern_elimination list -> stack -> fconstr list * stack_member list
+val apply_rules : clos_infos -> clos_tab -> fconstr -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * stack_member list
 
 val lift_fconstr      : int -> fconstr -> fconstr
 val lift_fconstr_vect : int -> fconstr array -> fconstr array

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -250,12 +250,10 @@ val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit
 (***********************************************************************
   i This is for lazy debug *)
 
-type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PECase of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array | PEProj of Projection.t
-
-val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
-val hard_match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
-val apply_rule : clos_infos -> clos_tab -> fconstr -> fconstr list -> pattern_elimination list -> stack -> fconstr list * stack_member list
-val apply_rules : clos_infos -> clos_tab -> fconstr -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * stack_member list
+val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
+val hard_match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list * Univ.Level.t list
+val apply_rule : clos_infos -> clos_tab -> fconstr -> fconstr list * Univ.Level.t list -> Declarations.pattern_elimination list -> stack -> (fconstr list * Univ.Level.t list) * stack_member list
+val apply_rules : clos_infos -> clos_tab -> fconstr -> Univ.Instance.t -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * Univ.Level.t list * stack_member list
 
 val lift_fconstr      : int -> fconstr -> fconstr
 val lift_fconstr_vect : int -> fconstr array -> fconstr array

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -253,7 +253,7 @@ val set_conv : (clos_infos -> clos_tab -> fconstr -> fconstr -> bool) -> unit
 type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PECase of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array | PEProj of Projection.t
 
 val match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
-val match_arg_pattern' : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
+val hard_match_arg_pattern : clos_infos -> clos_tab -> Declarations.rewrite_arg_pattern -> fconstr -> fconstr list
 val apply_rule : clos_infos -> clos_tab -> fconstr -> fconstr list -> pattern_elimination list -> stack -> fconstr list * stack_member list
 val apply_rules : clos_infos -> clos_tab -> fconstr -> Declarations.rewrite_rule list -> stack -> constr * fconstr list * stack_member list
 

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -258,7 +258,7 @@ type ('constr, 'types, 'sort, 'univs) kind_of_term =
   | Const     of (Constant.t * 'univs)
   (** Gallina-variable that was introduced by Vernacular-command that
      extends the global environment (i.e. [Parameter], or [Axiom], or
-     [Definition], or [Theorem] etc.) *)
+     [Definition], or [Theorem], or [Symbol] etc.) *)
   | Ind       of (inductive * 'univs)
   (** A name of an inductive type defined by [Variant], [Inductive] or
      [Record] Vernacular-commands. *)

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -284,7 +284,7 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 
 type rewrite_arg_pattern =
   | APHole
-  (* | APHoleIgnored *)
+  | APHoleIgnored
   | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
   | APInd     of inductive
   | APConstr  of constructor

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -287,16 +287,21 @@ type rewrite_arg_pattern =
   | APHole
   | APHoleIgnored
   | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
-  | APInd     of inductive
-  | APConstr  of constructor
+  | APInd     of inductive * bool array
+  | APConstr  of constructor * bool array
   | APInt     of Uint63.t
   | APFloat   of Float64.t
 
 type rewrite_pattern =
   | PApp      of rewrite_pattern * rewrite_arg_pattern array
-  | PConst    of Constant.t  (* Symbol *)
-  | PCase     of inductive * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
+  | PConst    of Constant.t * bool array  (* Symbol *)
+  | PCase     of inductive * bool array * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
   | PProj     of Projection.t * rewrite_pattern
+
+type pattern_elimination =
+  | PEApp     of rewrite_arg_pattern array
+  | PECase    of inductive * bool array * rewrite_arg_pattern * rewrite_arg_pattern array
+  | PEProj    of Projection.t
 
 type rewrite_rule = {
   lhs_pat : rewrite_pattern;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -307,9 +307,16 @@ type rewrite_pattern =
   | PProj     of Projection.t * rewrite_pattern
 
 type pattern_elimination =
-  | PEApp     of rewrite_arg_pattern array
-  | PECase    of inductive * bool array * rewrite_arg_pattern * rewrite_arg_pattern array
+  | PEApp     of pattern_argument array
+  | PECase    of inductive * bool array * pattern_argument * pattern_argument array
   | PEProj    of Projection.t
+
+and head_elimination = head_pattern * pattern_elimination list
+
+and pattern_argument =
+  | EHole
+  | EHoleIgnored
+  | ERigid of head_elimination
 
 type rewrite_rule = {
   lhs_pat : rewrite_pattern;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -283,22 +283,26 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 
 (** {6 Rewrite rules } *)
 
+type head_pattern =
+  | PHSort    of (Sorts.family * bool array)
+  | PHSymbol  of Constant.t * bool array
+  | PHInd     of inductive * bool array
+  | PHConstr  of constructor * bool array
+  | PHInt     of Uint63.t
+  | PHFloat   of Float64.t
+
 type rewrite_arg_pattern =
   | APHole
   | APHoleIgnored
   | APRigid   of rigid_arg_pattern
 and rigid_arg_pattern =
   | APApp     of rigid_arg_pattern * rewrite_arg_pattern array
-  | APSort    of (Sorts.family * bool array)
-  | APSymbol  of Constant.t * bool array
-  | APInd     of inductive * bool array
-  | APConstr  of constructor * bool array
-  | APInt     of Uint63.t
-  | APFloat   of Float64.t
+  | APHead    of head_pattern
+
 
 type rewrite_pattern =
   | PApp      of rewrite_pattern * rewrite_arg_pattern array
-  | PConst    of Constant.t * bool array  (* Symbol *)
+  | PHead     of Constant.t * bool array
   | PCase     of inductive * bool array * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
   | PProj     of Projection.t * rewrite_pattern
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -283,13 +283,15 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 
 (** {6 Rewrite rules } *)
 
-type head_pattern =
+type 'arg head_pattern =
   | PHSort    of (Sorts.family * bool array)
   | PHSymbol  of Constant.t * bool array
   | PHInd     of inductive * bool array
   | PHConstr  of constructor * bool array
   | PHInt     of Uint63.t
   | PHFloat   of Float64.t
+  | PHLambda  of 'arg array * 'arg
+  | PHProd    of 'arg array * 'arg
 
 type rewrite_arg_pattern =
   | APHole
@@ -297,7 +299,7 @@ type rewrite_arg_pattern =
   | APRigid   of rigid_arg_pattern
 and rigid_arg_pattern =
   | APApp     of rigid_arg_pattern * rewrite_arg_pattern array
-  | APHead    of head_pattern
+  | APHead    of rewrite_arg_pattern head_pattern
 
 
 type rewrite_pattern =
@@ -311,7 +313,7 @@ type pattern_elimination =
   | PECase    of inductive * bool array * pattern_argument * pattern_argument array
   | PEProj    of Projection.t
 
-and head_elimination = head_pattern * pattern_elimination list
+and head_elimination = pattern_argument head_pattern * pattern_elimination list
 
 and pattern_argument =
   | EHole

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -47,11 +47,12 @@ type inline = int option
     transparent body, or an opaque one *)
 
 (* Global declarations (i.e. constants) can be either: *)
-type ('a, 'opaque) constant_def =
+type ('a, 'opaque, 'rules) constant_def =
   | Undef of inline                       (** a global assumption *)
   | Def of 'a                             (** or a transparent global definition *)
   | OpaqueDef of 'opaque                  (** or an opaque global definition *)
   | Primitive of CPrimitives.t (** or a primitive operation *)
+  | Symbol of 'rules                      (** or a symbol *)
 
 type universes =
   | Monomorphic
@@ -109,7 +110,7 @@ type typing_flags = {
 type 'opaque pconstant_body = {
     const_hyps : Constr.named_context; (** younger hyp at top *)
     const_univ_hyps : Univ.Instance.t;
-    const_body : (Constr.t, 'opaque) constant_def;
+    const_body : (Constr.t, 'opaque, unit) constant_def;
     const_type : types;
     const_relevance : Sorts.relevance;
     const_body_code : Vmemitcodes.body_code option;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -286,7 +286,11 @@ type mind_specif = mutual_inductive_body * one_inductive_body
 type rewrite_arg_pattern =
   | APHole
   | APHoleIgnored
-  | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
+  | APRigid   of rigid_arg_pattern
+and rigid_arg_pattern =
+  | APApp     of rigid_arg_pattern * rewrite_arg_pattern array
+  | APSort    of (Sorts.family * bool array)
+  | APSymbol  of Constant.t * bool array
   | APInd     of inductive * bool array
   | APConstr  of constructor * bool array
   | APInt     of Uint63.t

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -320,13 +320,10 @@ and pattern_argument =
   | EHoleIgnored
   | ERigid of head_elimination
 
-(* equation between two hole indices *)
-type hole_equation =
-  | HEEq of int * int
-
 type rewrite_rule = {
   lhs_pat : rewrite_pattern;
-  lhs_eqs : hole_equation list;
+  (* lhs_eqs[i] is j if there is an equation between hole i and hole j. We should always have i > j. *)
+  lhs_eqs : int Int.Map.t;
   rhs : constr;
 }
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -320,8 +320,13 @@ and pattern_argument =
   | EHoleIgnored
   | ERigid of head_elimination
 
+(* equation between two hole indices *)
+type hole_equation =
+  | HEEq of int * int
+
 type rewrite_rule = {
   lhs_pat : rewrite_pattern;
+  lhs_eqs : hole_equation list;
   rhs : constr;
 }
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -110,7 +110,7 @@ type typing_flags = {
 type 'opaque pconstant_body = {
     const_hyps : Constr.named_context; (** younger hyp at top *)
     const_univ_hyps : Univ.Instance.t;
-    const_body : (Constr.t, 'opaque, unit) constant_def;
+    const_body : (Constr.t, 'opaque, bool) constant_def;
     const_type : types;
     const_relevance : Sorts.relevance;
     const_body_code : Vmemitcodes.body_code option;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -280,6 +280,28 @@ type mutual_inductive_body = {
 
 type mind_specif = mutual_inductive_body * one_inductive_body
 
+(** {6 Rewrite rules } *)
+
+type rewrite_arg_pattern =
+  | APHole
+  (* | APHoleIgnored *)
+  | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
+  | APInd     of inductive
+  | APConstr  of constructor
+  | APInt     of Uint63.t
+  | APFloat   of Float64.t
+
+type rewrite_pattern =
+  | PApp      of rewrite_pattern * rewrite_arg_pattern array
+  | PConst    of Constant.t  (* Symbol *)
+  | PCase     of inductive * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
+  | PProj     of Projection.t * rewrite_pattern
+
+type rewrite_rule = {
+  lhs_pat : rewrite_pattern;
+  rhs : constr;
+}
+
 (** {6 Module declarations } *)
 
 (** Functor expressions are forced to be on top of other expressions *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -77,7 +77,7 @@ let constant_is_polymorphic cb =
 
 
 let constant_has_body cb = match cb.const_body with
-  | Undef _ | Primitive _ -> false
+  | Undef _ | Primitive _ | Symbol _ -> false
   | Def _ | OpaqueDef _ -> true
 
 let constant_polymorphic_context cb =
@@ -85,7 +85,7 @@ let constant_polymorphic_context cb =
 
 let is_opaque cb = match cb.const_body with
   | OpaqueDef _ -> true
-  | Undef _ | Def _ | Primitive _ -> false
+  | Undef _ | Def _ | Primitive _ | Symbol _ -> false
 
 (** {7 Constant substitutions } *)
 
@@ -101,7 +101,7 @@ let subst_const_type subst arity =
 (** No need here to check for physical equality after substitution,
     at least for Def due to the delayed substitution [subst_constr_subst]. *)
 let subst_const_def subst def = match def with
-  | Undef _ | Primitive _ -> def
+  | Undef _ | Primitive _ | Symbol _ -> def
   | Def c -> Def (subst_mps subst c)
   | OpaqueDef o -> OpaqueDef (Opaqueproof.subst_opaque subst o)
 
@@ -140,6 +140,7 @@ let hcons_rel_context l = List.Smart.map hcons_rel_decl l
 let hcons_const_def = function
   | Undef inl -> Undef inl
   | Primitive p -> Primitive p
+  | Symbol r -> Symbol r
   | Def l_constr ->
     Def (Constr.hcons l_constr)
   | OpaqueDef _ as x -> x (* hashconsed when turned indirect *)

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -22,7 +22,7 @@ module RelDecl = Context.Rel.Declaration
 type inline = bool
 
 type 'opaque result = {
-  cook_body : (constr, 'opaque) constant_def;
+  cook_body : (constr, 'opaque, unit) constant_def;
   cook_type : types;
   cook_universes : universes;
   cook_relevance : Sorts.relevance;
@@ -79,6 +79,7 @@ let cook_constant env info cb =
   | OpaqueDef o ->
     OpaqueDef (Opaqueproof.discharge_opaque info o)
   | Primitive _ -> CErrors.anomaly (Pp.str "Primitives cannot be cooked")
+  | Symbol _ -> CErrors.anomaly (Pp.str "Symbols cannot be cooked")
   in
   let tps = Vmbytegen.compile_constant_body ~fail_on_error:false env univs body in
   let typ = abstract_as_type cache cb.const_type in

--- a/kernel/discharge.ml
+++ b/kernel/discharge.ml
@@ -22,7 +22,7 @@ module RelDecl = Context.Rel.Declaration
 type inline = bool
 
 type 'opaque result = {
-  cook_body : (constr, 'opaque, unit) constant_def;
+  cook_body : (constr, 'opaque, bool) constant_def;
   cook_type : types;
   cook_universes : universes;
   cook_relevance : Sorts.relevance;

--- a/kernel/discharge.mli
+++ b/kernel/discharge.mli
@@ -15,7 +15,7 @@ open Constr
 type inline = bool
 
 type 'opaque result = {
-  cook_body : (constr, 'opaque, unit) constant_def;
+  cook_body : (constr, 'opaque, bool) constant_def;
   cook_type : types;
   cook_universes : universes;
   cook_relevance : Sorts.relevance;

--- a/kernel/discharge.mli
+++ b/kernel/discharge.mli
@@ -15,7 +15,7 @@ open Constr
 type inline = bool
 
 type 'opaque result = {
-  cook_body : (constr, 'opaque) constant_def;
+  cook_body : (constr, 'opaque, unit) constant_def;
   cook_type : types;
   cook_universes : universes;
   cook_relevance : Sorts.relevance;

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -105,6 +105,7 @@ type primitive_entry = {
 
 type symbol_entry = {
   symb_entry_type : types;
+  symb_entry_unfold_fix: bool;
   symb_entry_universes : universes_entry;
 }
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -103,12 +103,18 @@ type primitive_entry = {
   prim_entry_content : CPrimitives.op_or_type;
 }
 
+type symbol_entry = {
+  symb_entry_type : types;
+  symb_entry_universes : universes_entry;
+}
+
 type 'a proof_output = constr Univ.in_universe_context_set * 'a
 
 type constant_entry =
   | DefinitionEntry : definition_entry -> constant_entry
   | ParameterEntry : parameter_entry -> constant_entry
   | PrimitiveEntry : primitive_entry -> constant_entry
+  | SymbolEntry : symbol_entry -> constant_entry
 
 (** {6 Modules } *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -213,6 +213,15 @@ let lookup_constant kn env =
 
 let mem_constant kn env = Cmap_env.mem kn env.env_globals.Globals.constants
 
+let add_rewrite_rule c r env =
+  let add = function
+    | None -> Some [r]
+    | Some rs -> Some (r::rs)
+  in
+  { env with
+    symb_pats = Cmap_env.update c add env.symb_pats
+  }
+
 (* Mutual Inductives *)
 let lookup_mind_key kn env =
   match Mindmap_env.find_opt kn env.env_globals.Globals.inductives with

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -83,7 +83,7 @@ type env = {
   env_universes_lbound : UGraph.Bound.t;
   irr_constants : Cset_env.t;
   irr_inds : Indset_env.t;
-  symb_pats: Rewrite_rule.t list Cmap_env.t;
+  symb_pats: rewrite_rule list Cmap_env.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
 }

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -83,6 +83,7 @@ type env = {
   env_universes_lbound : UGraph.Bound.t;
   irr_constants : Cset_env.t;
   irr_inds : Indset_env.t;
+  symb_pats: Rewrite_rule.t list Cmap_env.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
 }
@@ -112,6 +113,7 @@ let empty_env = {
   env_universes_lbound = UGraph.Bound.Set;
   irr_constants = Cset_env.empty;
   irr_inds = Indset_env.empty;
+  symb_pats = Cmap_env.empty;
   env_typing_flags = Declareops.safe_flags Conv_oracle.empty;
   retroknowledge = Retroknowledge.empty;
 }

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -238,6 +238,102 @@ let mind_context env mind =
   let mib = lookup_mind mind env in
   Declareops.inductive_polymorphic_context mib
 
+
+(** {6 Changes of representation of Case nodes} *)
+
+(* raises an anomaly if not an inductive type *)
+let lookup_mind_specif env (kn, tyi) =
+  let mib = lookup_mind kn env in
+  if tyi >= Array.length mib.mind_packets then
+    user_err Pp.(str "Inductive.lookup_mind_specif: invalid inductive index");
+  (mib, mib.mind_packets.(tyi))
+
+(** Provided:
+    - a universe instance [u]
+    - a term substitution [subst]
+    - name replacements [nas]
+    [instantiate_context u subst nas ctx] applies both [u] and [subst] to [ctx]
+    while replacing names using [nas] (order reversed)
+*)
+let instantiate_context u subst nas ctx =
+  let rec instantiate i ctx = match ctx with
+  | [] -> assert (Int.equal i (-1)); []
+  | LocalAssum (_, ty) :: ctx ->
+    let ctx = instantiate (pred i) ctx in
+    let ty = substnl subst i (subst_instance_constr u ty) in
+    LocalAssum (nas.(i), ty) :: ctx
+  | LocalDef (_, ty, bdy) :: ctx ->
+    let ctx = instantiate (pred i) ctx in
+    let ty = substnl subst i (subst_instance_constr u ty) in
+    let bdy = substnl subst i (subst_instance_constr u bdy) in
+    LocalDef (nas.(i), ty, bdy) :: ctx
+  in
+  instantiate (Array.length nas - 1) ctx
+
+let expand_case_specif mib (ci, u, params, p, iv, c, br) =
+  (* Γ ⊢ c : I@{u} params args *)
+  (* Γ, indices, self : I@{u} params indices ⊢ p : Type *)
+  let open Univ in
+  let mip = mib.mind_packets.(snd ci.ci_ind) in
+  let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
+  let paramsubst = Vars.subst_of_rel_context_instance paramdecl params in
+  (* Expand the return clause *)
+  let ep =
+    let (nas, p) = p in
+    let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
+    let self =
+      let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
+      let inst = Instance.of_array (Array.init (Instance.length u) Level.var) in
+      mkApp (mkIndU (ci.ci_ind, inst), args)
+    in
+    let realdecls = LocalAssum (Context.anonR, self) :: realdecls in
+    let realdecls = instantiate_context u paramsubst nas realdecls in
+    Term.it_mkLambda_or_LetIn p realdecls
+  in
+  (* Expand the branches *)
+  let ebr =
+    let build_one_branch i (nas, br) (ctx, _) =
+      let ctx, _ = List.chop mip.mind_consnrealdecls.(i) ctx in
+      let ctx = instantiate_context u paramsubst nas ctx in
+      Term.it_mkLambda_or_LetIn br ctx
+    in
+    Array.map2_i build_one_branch br mip.mind_nf_lc
+  in
+  (ci, ep, iv, c, ebr)
+
+let expand_case env (ci, _, _, _, _, _, _ as case) =
+  let specif = lookup_mind (fst ci.ci_ind) env in
+  expand_case_specif specif case
+
+let contract_case env (ci, p, iv, c, br) =
+  let (mib, mip) = lookup_mind_specif env ci.ci_ind in
+  let (arity, p) = Term.decompose_lambda_n_decls (mip.mind_nrealdecls + 1) p in
+  let (u, pms) = match arity with
+  | LocalAssum (_, ty) :: _ ->
+    (** Last binder is the self binder for the term being eliminated *)
+    let (ind, args) = decompose_appvect ty in
+    let (ind, u) = destInd ind in
+    let () = assert (Ind.CanOrd.equal ind ci.ci_ind) in
+    let pms = Array.sub args 0 mib.mind_nparams in
+    (** Unlift the parameters from under the index binders *)
+    let dummy = List.make mip.mind_nrealdecls mkProp in
+    let pms = Array.map (fun c -> Vars.substl dummy c) pms in
+    (u, pms)
+  | _ -> assert false
+  in
+  let p =
+    let nas = Array.of_list (List.rev_map get_annot arity) in
+    (nas, p)
+  in
+  let map i br =
+    let (ctx, br) = Term.decompose_lambda_n_decls mip.mind_consnrealdecls.(i) br in
+    let nas = Array.of_list (List.rev_map get_annot ctx) in
+    (nas, br)
+  in
+  (ci, u, pms, p, iv, c, Array.mapi map br)
+
+
+
 let oracle env = env.env_typing_flags.conv_oracle
 let set_oracle env o =
   let env_typing_flags = { env.env_typing_flags with conv_oracle = o } in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -655,6 +655,12 @@ let is_primitive env c =
   | Declarations.Primitive _ -> true
   | _ -> false
 
+let is_symbol env c =
+  let cb = lookup_constant c env in
+  match cb.Declarations.const_body with
+  | Declarations.Symbol _ -> true
+  | _ -> false
+
 let get_primitive env c =
   let cb = lookup_constant c env in
   match cb.Declarations.const_body with

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -600,7 +600,7 @@ type const_evaluation_result =
   | NoBody
   | Opaque
   | IsPrimitive of Univ.Instance.t * CPrimitives.t
-  | HasRules of rewrite_rule list
+  | HasRules of bool * rewrite_rule list
 
 exception NotEvaluableConst of const_evaluation_result
 
@@ -632,9 +632,9 @@ let constant_value_in env (kn,u) =
     | OpaqueDef _ -> raise (NotEvaluableConst Opaque)
     | Undef _ -> raise (NotEvaluableConst NoBody)
     | Primitive p -> raise (NotEvaluableConst (IsPrimitive (u,p)))
-    | Symbol _ ->
+    | Symbol b ->
         match Cmap_env.find_opt kn env.symb_pats with
-        | Some r -> raise (NotEvaluableConst (HasRules r))
+        | Some r -> raise (NotEvaluableConst (HasRules (b, r)))
         | None -> assert false
 
 let constant_opt_value_in env cst =

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -212,7 +212,7 @@ type const_evaluation_result =
   | NoBody
   | Opaque
   | IsPrimitive of Univ.Instance.t * CPrimitives.t
-  | HasRules of rewrite_rule list
+  | HasRules of bool * rewrite_rule list
 exception NotEvaluableConst of const_evaluation_result
 
 val constant_type : env -> Constant.t puniverses -> types constrained

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -194,6 +194,8 @@ val evaluable_constant : Constant.t -> env -> bool
 
 val mem_constant : Constant.t -> env -> bool
 
+val add_rewrite_rule : Constant.t -> rewrite_rule -> env -> env
+
 (** New-style polymorphism *)
 val polymorphic_constant  : Constant.t -> env -> bool
 val polymorphic_pconstant : pconstant -> env -> bool

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -212,6 +212,7 @@ type const_evaluation_result =
   | NoBody
   | Opaque
   | IsPrimitive of Univ.Instance.t * CPrimitives.t
+  | HasRules of rewrite_rule list
 exception NotEvaluableConst of const_evaluation_result
 
 val constant_type : env -> Constant.t puniverses -> types constrained

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -230,6 +230,7 @@ val constant_value_in : env -> Constant.t puniverses -> constr
 val constant_type_in : env -> Constant.t puniverses -> types
 val constant_opt_value_in : env -> Constant.t puniverses -> constr option
 
+val is_symbol : env -> Constant.t -> bool
 val is_primitive : env -> Constant.t -> bool
 val get_primitive : env -> Constant.t -> CPrimitives.t option
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -74,7 +74,7 @@ type env = private {
   env_universes_lbound : UGraph.Bound.t;
   irr_constants : Cset_env.t;
   irr_inds : Indset_env.t;
-  symb_pats : Rewrite_rule.t list Cmap_env.t;
+  symb_pats : rewrite_rule list Cmap_env.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
 }

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -263,6 +263,23 @@ val mem_mind : MutInd.t -> env -> bool
     polymorphic *)
 val mind_context : env -> MutInd.t -> Univ.AbstractContext.t
 
+(** Given a pattern-matching represented compactly, expands it so as to produce
+    lambda and let abstractions in front of the return clause and the pattern
+    branches. *)
+val expand_case : env -> case -> (case_info * constr * case_invert * constr * constr array)
+
+val expand_case_specif : Declarations.mutual_inductive_body -> case -> (case_info * constr * case_invert * constr * constr array)
+
+(** Dual operation of the above. Fails if the return clause or branch has not
+    the expected form. *)
+val contract_case : env -> (case_info * constr * case_invert * constr * constr array) -> case
+
+(** [instantiate_context u subst nas ctx] applies both [u] and [subst]
+    to [ctx] while replacing names using [nas] (order reversed). In particular,
+    assumes that [ctx] and [nas] have the same length. *)
+val instantiate_context : Instance.t -> Vars.substl -> Name.t Context.binder_annot array ->
+    rel_context -> rel_context
+
 (** New-style polymorphism *)
 val polymorphic_ind  : inductive -> env -> bool
 val polymorphic_pind : pinductive -> env -> bool

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -74,6 +74,7 @@ type env = private {
   env_universes_lbound : UGraph.Bound.t;
   irr_constants : Cset_env.t;
   irr_inds : Indset_env.t;
+  symb_pats : Rewrite_rule.t list Cmap_env.t;
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
 }

--- a/kernel/genlambda.ml
+++ b/kernel/genlambda.ml
@@ -710,7 +710,7 @@ and lambda_of_app cache env sigma f args =
         else
           let t = Val.get_constant (kn, u) cb in
           mkLapp t (lambda_of_args cache env sigma 0 args)
-      | OpaqueDef _ | Undef _ ->
+      | OpaqueDef _ | Undef _ | Symbol _ ->
           mkLapp (Lconst (kn, u)) (lambda_of_args cache env sigma 0 args)
       end
   | Construct ((ind,_ as c),_) ->

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -325,81 +325,13 @@ let is_primitive_record (mib,_) =
     [instantiate_context u subst nas ctx] applies both [u] and [subst] to [ctx]
     while replacing names using [nas] (order reversed)
 *)
-let instantiate_context u subst nas ctx =
-  let rec instantiate i ctx = match ctx with
-  | [] -> assert (Int.equal i (-1)); []
-  | LocalAssum (_, ty) :: ctx ->
-    let ctx = instantiate (pred i) ctx in
-    let ty = substnl subst i (subst_instance_constr u ty) in
-    LocalAssum (nas.(i), ty) :: ctx
-  | LocalDef (_, ty, bdy) :: ctx ->
-    let ctx = instantiate (pred i) ctx in
-    let ty = substnl subst i (subst_instance_constr u ty) in
-    let bdy = substnl subst i (subst_instance_constr u bdy) in
-    LocalDef (nas.(i), ty, bdy) :: ctx
-  in
-  instantiate (Array.length nas - 1) ctx
+let instantiate_context = Environ.instantiate_context
 
-let expand_case_specif mib (ci, u, params, p, iv, c, br) =
-  (* Γ ⊢ c : I@{u} params args *)
-  (* Γ, indices, self : I@{u} params indices ⊢ p : Type *)
-  let mip = mib.mind_packets.(snd ci.ci_ind) in
-  let paramdecl = Vars.subst_instance_context u mib.mind_params_ctxt in
-  let paramsubst = Vars.subst_of_rel_context_instance paramdecl params in
-  (* Expand the return clause *)
-  let ep =
-    let (nas, p) = p in
-    let realdecls, _ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in
-    let self =
-      let args = Context.Rel.instance mkRel 0 mip.mind_arity_ctxt in
-      let inst = Instance.of_array (Array.init (Instance.length u) Level.var) in
-      mkApp (mkIndU (ci.ci_ind, inst), args)
-    in
-    let realdecls = LocalAssum (Context.anonR, self) :: realdecls in
-    let realdecls = instantiate_context u paramsubst nas realdecls in
-    Term.it_mkLambda_or_LetIn p realdecls
-  in
-  (* Expand the branches *)
-  let ebr =
-    let build_one_branch i (nas, br) (ctx, _) =
-      let ctx, _ = List.chop mip.mind_consnrealdecls.(i) ctx in
-      let ctx = instantiate_context u paramsubst nas ctx in
-      Term.it_mkLambda_or_LetIn br ctx
-    in
-    Array.map2_i build_one_branch br mip.mind_nf_lc
-  in
-  (ci, ep, iv, c, ebr)
+let expand_case_specif = Environ.expand_case_specif
 
-let expand_case env (ci, _, _, _, _, _, _ as case) =
-  let specif = Environ.lookup_mind (fst ci.ci_ind) env in
-  expand_case_specif specif case
+let expand_case = Environ.expand_case
 
-let contract_case env (ci, p, iv, c, br) =
-  let (mib, mip) = lookup_mind_specif env ci.ci_ind in
-  let (arity, p) = Term.decompose_lambda_n_decls (mip.mind_nrealdecls + 1) p in
-  let (u, pms) = match arity with
-  | LocalAssum (_, ty) :: _ ->
-    (** Last binder is the self binder for the term being eliminated *)
-    let (ind, args) = decompose_appvect ty in
-    let (ind, u) = destInd ind in
-    let () = assert (Ind.CanOrd.equal ind ci.ci_ind) in
-    let pms = Array.sub args 0 mib.mind_nparams in
-    (** Unlift the parameters from under the index binders *)
-    let dummy = List.make mip.mind_nrealdecls mkProp in
-    let pms = Array.map (fun c -> Vars.substl dummy c) pms in
-    (u, pms)
-  | _ -> assert false
-  in
-  let p =
-    let nas = Array.of_list (List.rev_map get_annot arity) in
-    (nas, p)
-  in
-  let map i br =
-    let (ctx, br) = Term.decompose_lambda_n_decls mip.mind_consnrealdecls.(i) br in
-    let nas = Array.of_list (List.rev_map get_annot ctx) in
-    (nas, br)
-  in
-  (ci, u, pms, p, iv, c, Array.mapi map br)
+let contract_case = Environ.contract_case
 
 (************************************************************************)
 (* Type of case branches *)

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -90,7 +90,7 @@ let rec check_with_def (cst, ustate) env struc (idl,(c,ctx)) mp reso =
               cst
             | Def c' ->
               infer_gen_conv (cst, ustate) env' c c'
-            | Primitive _ ->
+            | Primitive _ | Symbol _ ->
               error_incorrect_with_constraint lab
           in
           Monomorphic, cst
@@ -115,7 +115,7 @@ let rec check_with_def (cst, ustate) env struc (idl,(c,ctx)) mp reso =
                 try Reduction.conv env' c c'
                 with Reduction.NotConvertible -> error_incorrect_with_constraint lab
               end
-            | Primitive _ ->
+            | Primitive _ | Symbol _ ->
               error_incorrect_with_constraint lab
           in
           Polymorphic ctx, cst

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -577,7 +577,7 @@ let inline_delta_resolver env inl mp mbid mtb delta =
         let constant = lookup_constant con env in
         let l = make_inline delta r in
         match constant.const_body with
-        | Undef _ | OpaqueDef _ | Primitive _ -> l
+        | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> l
         | Def constr ->
           let ctx = Declareops.constant_polymorphic_context constant in
           let constr = Univ.{univ_abstracted_value=constr; univ_abstracted_binder=ctx} in

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -67,7 +67,7 @@ struct
   let check_inductive _ _ = ()
   let get_constant knu cb = match cb.const_body with
   | Def body -> if is_lazy body then mkLapp Lforce [|Lconst knu|] else Lconst knu
-  | Undef _ | OpaqueDef _ | Primitive _ -> assert false
+  | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> assert false
 end
 
 module Lambda = Genlambda.Make(Val)

--- a/kernel/rewrite_rule.ml
+++ b/kernel/rewrite_rule.ml
@@ -13,11 +13,15 @@ open Names
 open Constr
 open Declarations
 
+let mask_of_instance =
+  Univ.Instance.to_array %>
+  Array.map (Univ.Level.var_index %> Option.has_some)
+
 let rec arg_pattern_of_constr t = kind t |> function
   | Rel _ -> APHole
   | App (f, args) -> APApp (arg_pattern_of_constr f, Array.map arg_pattern_of_constr args)
-  | Ind (ind, _) -> APInd ind
-  | Construct (c, _) -> APConstr c
+  | Ind (ind, u) -> APInd (ind, mask_of_instance u)
+  | Construct (c, u) -> APConstr (c, mask_of_instance u)
   | Int i -> APInt i
   | Float f -> APFloat f
   | _ -> assert false
@@ -32,31 +36,77 @@ let app_pattern_of_constr n t =
 let app_pattern_of_constr' p = app_pattern_of_constr (Array.length (fst p)) (snd p)
 
 let rec pattern_of_constr t = kind t |> function
-  | Const (c, _) -> PConst c
+  | Const (c, u) -> PConst (c, mask_of_instance u)
   | App (f, args) -> PApp (pattern_of_constr f, Array.map arg_pattern_of_constr args)
-  | Case (ci, _, _, p, _, c, brs) ->
-      PCase (ci.ci_ind, app_pattern_of_constr' p, pattern_of_constr c, Array.map app_pattern_of_constr' brs)
+  | Case (ci, u, _, p, _, c, brs) ->
+      PCase (ci.ci_ind, mask_of_instance u, app_pattern_of_constr' p, pattern_of_constr c, Array.map app_pattern_of_constr' brs)
   | Proj (p, c) -> PProj (p, pattern_of_constr c)
   | _ -> assert false
 
-let rec safe_arg_pattern_of_constr remvar t = kind t |> function
+type state = (int * int Int.Map.t) * (int * int Int.Map.t)
+
+let update_invtbl i curvar tbl =
+  succ curvar, tbl |> Int.Map.update i @@ function
+  | None -> Some curvar
+  | Some k as c when k = curvar -> c
+  | Some _ ->
+      CErrors.user_err
+        Pp.(str "Variable "
+          ++ Constr.debug_print (of_kind (Rel i))
+          ++ str" not used at the right place, expected "
+          ++ Constr.debug_print (of_kind (Rel curvar))
+          ++ str".")
+
+let update_shft_invtbl shft (state, stateu) i =
+  let (curvar, invtbl) = state in
+  if i <= shft then
+    CErrors.user_err
+      Pp.(str "Variable "
+        ++ Constr.debug_print (of_kind (Rel i))
+        ++ str" not available from toplevel.");
+  update_invtbl (i-shft) curvar invtbl, stateu
+
+let update_invtblu lvl curvaru tbl =
+  succ curvaru, tbl |> Int.Map.update lvl @@ function
+    | None -> Some curvaru
+    | Some k as c when k = curvaru -> c
+    | Some _ ->
+        CErrors.user_err
+          Pp.(str "Universe variable "
+            ++ Univ.Level.(pr (var lvl))
+            ++ str" not used at the right place, expected "
+            ++ Univ.Level.(pr (var curvaru))
+            ++ str".")
+
+let update_invtblu (state, stateu) u =
+  let u = Univ.Instance.to_array u in
+  let stateu, mask = Array.fold_left_map (fun (curvaru, invtblu) lvl ->
+      match Univ.Level.var_index lvl with
+      | Some lvl -> update_invtblu lvl curvaru invtblu, true
+      | None -> (curvaru, invtblu), false
+    ) stateu u
+  in
+  (state, stateu), mask
+
+let rec safe_arg_pattern_of_constr shft state t = kind t |> function
   | Rel i ->
-      if remvar <> i then CErrors.user_err Pp.(str "Variable " ++ Constr.debug_print t ++ str" not used at the right place, expected "++ Constr.debug_print (of_kind (Rel remvar)) ++str".");
-      (pred remvar, APHole)
+      let state = update_shft_invtbl shft state i in
+      state, APHole
   | App (f, args) ->
-      let remvar, pf = safe_arg_pattern_of_constr remvar f in
-      let remvar, pargs = Array.fold_left_map safe_arg_pattern_of_constr remvar args in
-      remvar, APApp (pf, pargs)
-  | Ind (ind, _) -> remvar, APInd ind
-  | Construct (c, _) -> remvar, APConstr c
-  | Int i -> remvar, APInt i
-  | Float f -> remvar, APFloat f
+      let state, pf = safe_arg_pattern_of_constr shft state f in
+      let state, pargs = Array.fold_left_map (safe_arg_pattern_of_constr shft) state args in
+      state, APApp (pf, pargs)
+  | Ind (ind, u) ->
+      let state, mask = update_invtblu state u in
+      state, APInd (ind, mask)
+  | Construct (c, u) ->
+      let state, mask = update_invtblu state u in
+      state, APConstr (c, mask)
+  | Int i -> state, APInt i
+  | Float f -> state, APFloat f
   | _ -> CErrors.user_err Pp.(str "Subterm not recognised as arg_pattern" ++ Constr.debug_print t)
 
-let shift_left n f =
-  fun n' a -> let n', a' = f (n + n') a in n' - n, a'
-
-let safe_app_pattern_of_constr remvar n t =
+let safe_app_pattern_of_constr shft ((curvar, invtbl), stateu) n t =
   let f, args = decompose_appvect t in
   let nargs = Array.length args in
   if not (nargs >= n) then CErrors.user_err Pp.(str "Subterm not recognised as pattern under binders" ++ Constr.debug_print t);
@@ -67,52 +117,78 @@ let safe_app_pattern_of_constr remvar n t =
       | t -> CErrors.user_err Pp.(str "Subterm not recognised as pattern under binders" ++ Constr.debug_print (of_kind t)))
     usedargs
   in
-  shift_left n safe_arg_pattern_of_constr remvar (mkApp (f, remargs))
+  safe_arg_pattern_of_constr (n + shft) ((curvar, invtbl), stateu) (mkApp (f, remargs))
 
-let safe_app_pattern_of_constr' remvar p = safe_app_pattern_of_constr remvar (Array.length (fst p)) (snd p)
+let safe_app_pattern_of_constr' shft state p = safe_app_pattern_of_constr shft state (Array.length (fst p)) (snd p)
 
 
-let rec safe_pattern_of_constr env remvar t = kind t |> function
-  | Const (c, _) ->
+let rec safe_pattern_of_constr env shft state t = kind t |> function
+  | Const (c, u) ->
       (match (Environ.lookup_constant c env).const_body with
       | Def _ | OpaqueDef _ | Primitive _ | Undef _ ->
           CErrors.user_err Pp.(str "Constant " ++ Constant.print c ++ str" used in pattern is not a symbol.")
       | Symbol _ -> ());
-      remvar, PConst c
+      let state, mask = update_invtblu state u in
+      state, PConst (c, mask)
   | App (f, args) ->
-      let remvar, pf = safe_pattern_of_constr env remvar f in
-      let remvar, pargs = Array.fold_left_map safe_arg_pattern_of_constr remvar args in
-      remvar, PApp (pf, pargs)
-  | Case (ci, _, _, ret, _, c, brs) ->
-      let remvar, pc = safe_pattern_of_constr env remvar c in
-      let remvar, pret = safe_app_pattern_of_constr' remvar ret in
-      let remvar, pbrs = Array.fold_left_map safe_app_pattern_of_constr' remvar brs in
-      remvar, PCase (ci.ci_ind, pret, pc, pbrs)
+      let state, pf = safe_pattern_of_constr env shft state f in
+      let state, pargs = Array.fold_left_map (safe_arg_pattern_of_constr shft) state args in
+      state, PApp (pf, pargs)
+  | Case (ci, u, _, ret, _, c, brs) ->
+      let state, mask = update_invtblu state u in
+      let state, pc = safe_pattern_of_constr env shft state c in
+      let state, pret = safe_app_pattern_of_constr' shft state ret in
+      let state, pbrs = Array.fold_left_map (safe_app_pattern_of_constr' shft) state brs in
+      state, PCase (ci.ci_ind, mask, pret, pc, pbrs)
   | Proj (p, c) ->
-      let remvar, pc = safe_pattern_of_constr env remvar c in
-      remvar, PProj (p, pc)
+      let state, pc = safe_pattern_of_constr env shft state c in
+      state, PProj (p, pc)
   | _ -> CErrors.user_err Pp.(str "Subterm not recognised as pattern" ++ Constr.debug_print t)
 
 let rec head_constant = function
-  | PConst c -> c
+  | PConst (c, _) -> c
   | PApp (h, _) -> head_constant h
-  | PCase (_, _, c, _) -> head_constant c
+  | PCase (_, _, _, c, _) -> head_constant c
   | PProj (_, c) -> head_constant c
+
+(* relocation of de Bruijn n in an explicit lift and a renaming table *)
+let reloc_ren_rel (shft, tbl) n =
+  if n <= shft then n else Int.Map.find (n-shft) tbl + shft
+
+let rec rename eltbl c =
+  match kind c with
+  | Rel i ->
+    let j = reloc_ren_rel eltbl i in
+    if Int.equal i j then c else mkRel j
+  | _ -> map_with_binders (on_fst succ) rename eltbl c
 
 let rule_of_constant env c =
   let cb = Environ.lookup_constant c env in
-  match cb.const_universes with
-  | Polymorphic _ ->
-    CErrors.user_err Pp.(str "Universe polymophic rewrite rules not supported yet.")
-  | Monomorphic ->
-    let ctx, eq_rule = Term.decompose_prod_decls cb.const_type in
-    match kind eq_rule with
-    (* XXX should be checking that the head is eq not some arbitrary inductive
-       Maybe by registering eq in retroknowledge *)
-    | App (hd, [|_;lhs;rhs|]) when isInd hd ->
-      let rem_hyps, lhs_pat = safe_pattern_of_constr env (Context.Rel.nhyps ctx) lhs in
-      assert (rem_hyps = 0);
-      head_constant lhs_pat, { lhs_pat = lhs_pat; rhs; }
-    | _ ->
+  let ctx, eq_rule = Term.decompose_prod_decls cb.const_type in
+  let lhs, rhs = match kind eq_rule with
+  (* XXX should be checking that the head is eq not some arbitrary inductive
+      Maybe by registering eq in retroknowledge *)
+  | App (hd, [|_;lhs;rhs|]) when isInd hd -> lhs, rhs
+  | _ ->
+    CErrors.user_err
+      Pp.(str "Cannot declare as rewrite rule: doesn't look like a proof of equality.")
+  in
+  let nvars = Context.Rel.nhyps ctx in
+  let nvarus = Univ.AbstractContext.size @@ Declareops.constant_polymorphic_context cb in
+  let ((seen_vars, invtbl), (_, invtblu)), lhs_pat =
+    safe_pattern_of_constr env 0 ((1, Int.Map.empty), (0, Int.Map.empty)) lhs
+  in
+  let seen_vars = pred seen_vars in
+  (* Rels begin at 1 *)
+  if not (seen_vars = nvars) then
+    CErrors.user_err
+      Pp.(str "Not all pattern variables appear in the pattern.");
+    Vars.universes_of_constr rhs |> Univ.Level.Set.iter (fun lvl -> lvl |> Univ.Level.var_index |> Option.iter (fun lvli ->
+    if not (Int.Map.mem lvli invtblu) then
       CErrors.user_err
-        Pp.(str "Cannot declare as rewrite rule: doesn't look like a proof of equality.")
+        Pp.(str "Universe level variable" ++ Univ.Level.pr lvl ++ str " appears in rhs but does not appear in the pattern.")
+  ));
+  let usubst = Univ.Instance.of_array (Array.init nvarus (fun i -> Univ.Level.var (Option.default i (Int.Map.find_opt i invtblu)))) in
+  Format.print_flush ();
+  head_constant lhs_pat, { lhs_pat = lhs_pat; rhs = rename (0, invtbl) (Vars.subst_instance_constr usubst rhs); }
+

--- a/kernel/rewrite_rule.ml
+++ b/kernel/rewrite_rule.ml
@@ -224,7 +224,7 @@ let rule_of_constant env c =
     CErrors.user_err
       Pp.(str "Cannot declare as rewrite rule: doesn't look like a proof of equality.")
   in
-  let nvars = Context.Rel.nhyps ctx in
+  let nvars = Context.Rel.length ctx in
   let nvarus = Univ.AbstractContext.size @@ Declareops.constant_polymorphic_context cb in
   let ((seen_vars, invtbl), (_, invtblu)), lhs_pat =
     safe_pattern_of_constr env 0 ((1, Int.Map.empty), (0, Int.Map.empty)) lhs

--- a/kernel/rewrite_rule.ml
+++ b/kernel/rewrite_rule.ml
@@ -1,0 +1,81 @@
+open Util
+open Names
+open Constr
+
+type case_info = { ci_ind: inductive }
+
+type rewrite_arg_pattern =
+  | APHole
+  (* | APHoleIgnored *)
+  | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
+  | APInd     of inductive
+  | APConstr  of constructor
+  | APInt     of Uint63.t
+  | APFloat   of Float64.t
+
+type rewrite_pattern =
+  | PApp      of rewrite_pattern * rewrite_arg_pattern array
+  | PConst    of Constant.t  (* Symbol *)
+  | PCase     of case_info * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
+  | PProj     of Projection.t * rewrite_pattern
+
+
+type rewrite_rule = {
+  lhs_pat : rewrite_pattern;
+  rhs : constr;
+}
+
+type t = rewrite_rule
+
+let rec arg_pattern_of_constr t = kind t |> function
+  | Rel _ -> APHole
+  | App (f, args) -> APApp (arg_pattern_of_constr f, Array.map arg_pattern_of_constr args)
+  | Ind (ind, _) -> APInd ind
+  | Construct (c, _) -> APConstr c
+  | Int i -> APInt i
+  | Float f -> APFloat f
+  | _ -> assert false
+
+let rec pattern_of_constr t = kind t |> function
+  | Const (c, _) -> PConst c
+  | App (f, args) -> PApp (pattern_of_constr f, Array.map arg_pattern_of_constr args)
+  | Case (ci, _, _, p, _, c, brs) -> PCase ({ci_ind = ci.Constr.ci_ind}, arg_pattern_of_constr (snd p), pattern_of_constr c, Array.map (fun (_, br) -> arg_pattern_of_constr br) brs)
+  | Proj (p, c) -> PProj (p, pattern_of_constr c)
+  | _ -> assert false
+
+let lookup_constant _env _c = assert false
+
+let rec safe_arg_pattern_of_constr nvar t = kind t |> function
+  | Rel i ->
+      if nvar <> i then CErrors.anomaly Pp.(str "Variable " ++ Constr.debug_print t ++ str" not used at the right place, expected "++ Constr.debug_print (of_kind (Rel nvar)) ++str".");
+      (succ nvar, APHole)
+  | App (f, args) ->
+      let nvar, pf = safe_arg_pattern_of_constr nvar f in
+      let nvar, pargs = Array.fold_left_map safe_arg_pattern_of_constr nvar args in
+      nvar, APApp (pf, pargs)
+  | Ind (ind, _) -> nvar, APInd ind
+  | Construct (c, _) -> nvar, APConstr c
+  | Int i -> nvar, APInt i
+  | Float f -> nvar, APFloat f
+  | _ -> CErrors.anomaly Pp.(str "Subterm not recognised as arg_pattern" ++ Constr.debug_print t)
+
+let rec safe_pattern_of_constr env nvar t = kind t |> function
+  | Const (c, _) ->
+      (match lookup_constant env c with
+      | Declarations.Def _ | Declarations.OpaqueDef _ | Declarations.Primitive _ ->
+          CErrors.anomaly Pp.(str "Constant " ++ Constant.print c ++ str" used in pattern has a body.")
+      | Declarations.Undef _ -> ());
+      nvar, PConst c
+  | App (f, args) ->
+      let nvar, pf = safe_pattern_of_constr env nvar f in
+      let nvar, pargs = Array.fold_left_map safe_arg_pattern_of_constr nvar args in
+      nvar, PApp (pf, pargs)
+  | Case (ci, _, _, (_, ret), _, c, brs) ->
+      let nvar, pc = safe_pattern_of_constr env nvar c in
+      let nvar, pret = safe_arg_pattern_of_constr nvar ret in
+      let nvar, pbrs = Array.fold_left_map (fun nvar (_, br) -> safe_arg_pattern_of_constr nvar br) nvar brs in
+      nvar, PCase ({ci_ind = ci.Constr.ci_ind}, pret, pc, pbrs)
+  | Proj (p, c) ->
+      let nvar, pc = safe_pattern_of_constr env nvar c in
+      nvar, PProj (p, pc)
+  | _ -> CErrors.anomaly Pp.(str "Subterm not recognised as pattern" ++ Constr.debug_print t)

--- a/kernel/rewrite_rule.mli
+++ b/kernel/rewrite_rule.mli
@@ -14,3 +14,5 @@ open Declarations
 val pattern_of_constr : constr -> rewrite_pattern
 
 val safe_pattern_of_constr : Environ.env -> int -> constr -> int * rewrite_pattern
+
+val rule_of_constant : Environ.env -> Names.Constant.t -> rewrite_rule

--- a/kernel/rewrite_rule.mli
+++ b/kernel/rewrite_rule.mli
@@ -15,4 +15,4 @@ val pattern_of_constr : constr -> rewrite_pattern
 
 val safe_pattern_of_constr : Environ.env -> int -> constr -> int * rewrite_pattern
 
-val rule_of_constant : Environ.env -> Names.Constant.t -> rewrite_rule
+val rule_of_constant : Environ.env -> Names.Constant.t -> Names.Constant.t * rewrite_rule

--- a/kernel/rewrite_rule.mli
+++ b/kernel/rewrite_rule.mli
@@ -1,0 +1,36 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open Constr
+
+type rewrite_arg_pattern =
+  | APHole
+  (* | APHoleIgnored *)
+  | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
+  | APInd     of inductive
+  | APConstr  of constructor
+  | APInt     of Uint63.t
+  | APFloat   of Float64.t
+
+type rewrite_pattern =
+  | PApp      of rewrite_pattern * rewrite_arg_pattern array
+  | PConst    of Constant.t  (* Symbol *)
+  | PCase     of inductive * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
+  | PProj     of Projection.t * rewrite_pattern
+
+type t = {
+  lhs_pat : rewrite_pattern;
+  rhs : constr;
+}
+
+val pattern_of_constr : constr -> rewrite_pattern
+
+val safe_pattern_of_constr : 'a -> int -> constr -> int * rewrite_pattern

--- a/kernel/rewrite_rule.mli
+++ b/kernel/rewrite_rule.mli
@@ -13,6 +13,8 @@ open Declarations
 
 val pattern_of_constr : constr -> rewrite_pattern
 
-val safe_pattern_of_constr : Environ.env -> int -> constr -> int * rewrite_pattern
+type state
+
+val safe_pattern_of_constr : Environ.env -> int -> state -> constr -> state * rewrite_pattern
 
 val rule_of_constant : Environ.env -> Names.Constant.t -> Names.Constant.t * rewrite_rule

--- a/kernel/rewrite_rule.mli
+++ b/kernel/rewrite_rule.mli
@@ -8,29 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Constr
-
-type rewrite_arg_pattern =
-  | APHole
-  (* | APHoleIgnored *)
-  | APApp     of rewrite_arg_pattern * rewrite_arg_pattern array
-  | APInd     of inductive
-  | APConstr  of constructor
-  | APInt     of Uint63.t
-  | APFloat   of Float64.t
-
-type rewrite_pattern =
-  | PApp      of rewrite_pattern * rewrite_arg_pattern array
-  | PConst    of Constant.t  (* Symbol *)
-  | PCase     of inductive * rewrite_arg_pattern * rewrite_pattern * rewrite_arg_pattern array
-  | PProj     of Projection.t * rewrite_pattern
-
-type t = {
-  lhs_pat : rewrite_pattern;
-  rhs : constr;
-}
+open Declarations
 
 val pattern_of_constr : constr -> rewrite_pattern
 
-val safe_pattern_of_constr : 'a -> int -> constr -> int * rewrite_pattern
+val safe_pattern_of_constr : Environ.env -> int -> constr -> int * rewrite_pattern

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -978,6 +978,17 @@ let add_private_constant l uctx decl senv : (Constant.t * private_constants) * s
   in
   (kn, eff), senv
 
+(** Rewrite rules *)
+
+let add_rewrite_rule c senv =
+  if Option.has_some senv.sections
+  then CErrors.user_err Pp.(str "Adding rewrite rules not supported in sections.");
+  let rule = Rewrite_rule.rule_of_constant senv.env c in
+  (* TODO add to the revstruct
+     TODO check that the lhs is not a defined symbol? *)
+  { senv with
+    env = Environ.add_rewrite_rule c rule senv.env }
+
 (** Insertion of inductive types *)
 
 let check_mind mie lab =

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -983,11 +983,11 @@ let add_private_constant l uctx decl senv : (Constant.t * private_constants) * s
 let add_rewrite_rule c senv =
   if Option.has_some senv.sections
   then CErrors.user_err Pp.(str "Adding rewrite rules not supported in sections.");
-  let rule = Rewrite_rule.rule_of_constant senv.env c in
+  let h, rule = Rewrite_rule.rule_of_constant senv.env c in
   (* TODO add to the revstruct
      TODO check that the lhs is not a defined symbol? *)
   { senv with
-    env = Environ.add_rewrite_rule c rule senv.env }
+    env = Environ.add_rewrite_rule h rule senv.env }
 
 (** Insertion of inductive types *)
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -373,7 +373,7 @@ let side_effects_of_private_constants l =
 let lift_constant c =
   let body = match c.const_body with
   | OpaqueDef _ -> Undef None
-  | Def _ | Undef _ | Primitive _ as body -> body
+  | Def _ | Undef _ | Primitive _ | Symbol _ as body -> body
   in
   { c with const_body = body }
 
@@ -840,7 +840,7 @@ let export_private_constants eff senv =
     let body = Constr.hcons body in
     let opaque = { exp_body = body; exp_handle = h; exp_univs = univs } in
     senv, (kn, { c with const_body = OpaqueDef o }, Some opaque)
-  | Def _ | Undef _ | Primitive _ as body ->
+  | Def _ | Undef _ | Primitive _ | Symbol _ as body ->
     senv, (kn, { c with const_body = body }, None)
   in
   let senv, bodies = List.fold_left_map map senv exported in
@@ -963,7 +963,7 @@ let add_private_constant l uctx decl senv : (Constant.t * private_constants) * s
        and depending of the opaque status of the latter, this proof term will be
        either inlined or reexported. *)
     { cb with const_body = Undef None }
-  | Undef _ | Primitive _ -> assert false
+  | Undef _ | Primitive _ | Symbol _ -> assert false
   in
   let senv = add_constant_aux senv (kn, dcb) in
   let eff =

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -123,6 +123,11 @@ val is_filled_opaque : Opaqueproof.opaque_handle -> safe_environment -> bool
 val repr_certificate : opaque_certificate ->
   Constr.t * Univ.ContextSet.t Opaqueproof.delayed_universes
 
+(** {5 Rewrite rules} *)
+
+(** Add a rewrite rule corresponding to the equality witnessed by the constant. *)
+val add_rewrite_rule : Constant.t -> safe_environment -> safe_environment
+
 (** {5 Inductive blocks} *)
 
 (** Adding an inductive type *)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -244,10 +244,10 @@ let check_constant (cst, ustate) env l info1 cb2 spec2 subst1 subst2 =
            anything of the right type can implement it, even if bodies differ.
       *)
       (match cb2.const_body with
-        | Primitive _ | Undef _ | OpaqueDef _ -> cst
+        | Primitive _ | Undef _ | OpaqueDef _ | Symbol _ -> cst
         | Def c2 ->
           (match cb1.const_body with
-            | Primitive _ | Undef _ | OpaqueDef _ -> error NotConvertibleBodyField
+            | Primitive _ | Undef _ | OpaqueDef _ | Symbol _ -> error NotConvertibleBodyField
             | Def c1 ->
               (* NB: cb1 might have been strengthened and appear as transparent.
                  Anyway [check_conv] will handle that afterwards. *)

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -130,13 +130,13 @@ let infer_primitive env { prim_entry_type = utyp; prim_entry_content = p; } =
     cook_univ_hyps = Instance.empty;
   }
 
-let infer_symbol env { symb_entry_universes; symb_entry_type } =
+let infer_symbol env { symb_entry_universes; symb_entry_unfold_fix; symb_entry_type } =
   let env, usubst, _, univs = process_universes env symb_entry_universes in
   let j = Typeops.infer env symb_entry_type in
   let r = Typeops.assumption_of_judgment env j in
   let t = Vars.subst_univs_level_constr usubst j.uj_val in
   {
-    Discharge.cook_body = Symbol ();
+    Discharge.cook_body = Symbol symb_entry_unfold_fix;
     cook_type = t;
     cook_universes = univs;
     cook_relevance = r;

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -908,7 +908,7 @@ let compile ~fail_on_error ?universes:(universes=0) env sigma c =
     fn msg; None
 
 let compile_constant_body ~fail_on_error env univs = function
-  | Undef _ | OpaqueDef _ | Primitive _ -> Some BCconstant
+  | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> Some BCconstant
   | Def body ->
       let instance_size = Univ.AbstractContext.size (Declareops.universes_context univs) in
       match kind body with

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -22,7 +22,7 @@ val compile :
 (** init, fun, fv *)
 
 val compile_constant_body : fail_on_error:bool ->
-  env -> universes -> (Constr.t, 'opaque) constant_def ->
+  env -> universes -> (Constr.t, 'opaque, unit) constant_def ->
   body_code option
 
 (** Shortcut of the previous function used during module strengthening *)

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -22,7 +22,7 @@ val compile :
 (** init, fun, fv *)
 
 val compile_constant_body : fail_on_error:bool ->
-  env -> universes -> (Constr.t, 'opaque, unit) constant_def ->
+  env -> universes -> (Constr.t, 'opaque, 'symb) constant_def ->
   body_code option
 
 (** Shortcut of the previous function used during module strengthening *)

--- a/library/global.ml
+++ b/library/global.ml
@@ -92,6 +92,7 @@ let export_private_constants cd = globalize (Safe_typing.export_private_constant
 let add_constant ?typing_flags id d = globalize (Safe_typing.add_constant ?typing_flags (i2l id) d)
 let add_private_constant id u d = globalize (Safe_typing.add_private_constant (i2l id) u d)
 let fill_opaque c = globalize0 (Safe_typing.fill_opaque c)
+let add_rewrite_rule c = globalize0 (Safe_typing.add_rewrite_rule c)
 let add_mind ?typing_flags id mie = globalize (Safe_typing.add_mind ?typing_flags (i2l id) mie)
 let add_modtype id me inl = globalize (Safe_typing.add_modtype (i2l id) me inl)
 let add_module id me inl = globalize (Safe_typing.add_module (i2l id) me inl)

--- a/library/global.ml
+++ b/library/global.ml
@@ -143,7 +143,7 @@ let force_proof access o = match access.access_proof o with
 let body_of_constant_body access env cb =
   let open Declarations in
   match cb.const_body with
-  | Undef _ | Primitive _ ->
+  | Undef _ | Primitive _ | Symbol _ ->
      None
   | Def c ->
     let u = match cb.const_universes with

--- a/library/global.mli
+++ b/library/global.mli
@@ -57,6 +57,7 @@ val add_constant :
 val fill_opaque : Safe_typing.opaque_certificate -> unit
 val add_private_constant :
   Id.t -> Univ.ContextSet.t -> Safe_typing.side_effect_declaration -> Constant.t * Safe_typing.private_constants
+val add_rewrite_rule : Constant.t -> unit
 val add_mind :
   ?typing_flags:typing_flags ->
   Id.t -> Entries.mutual_inductive_entry -> MutInd.t

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -124,7 +124,7 @@ let check_fix env sg cb i =
           | Fix ((_,j),recd) when Int.equal i j -> check_arity env cb; (true,recd)
           | CoFix (j,recd) when Int.equal i j -> check_arity env cb; (false,recd)
           | _ -> raise Impossible)
-    | Undef _ | OpaqueDef _ | Primitive _ -> raise Impossible
+    | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> raise Impossible
 
 let prec_declaration_equal sg (na1, ca1, ta1) (na2, ca2, ta2) =
   Array.equal (Context.eq_annot Name.equal) na1 na2 &&

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -309,7 +309,7 @@ let rec extract_type env sg db j c args =
            | (Info, Default) ->
                (* Not an ML type, for example [(c:forall X, X->X) Type nat] *)
                (match (lookup_constant kn env).const_body with
-                 | Undef _  | OpaqueDef _ | Primitive _ -> Tunknown (* Brutal approx ... *)
+                 | Undef _  | OpaqueDef _ | Primitive _ | Symbol _ -> Tunknown (* Brutal approx ... *)
                   | Def lbody ->
                       (* We try to reduce. *)
                       let newc = applistc (get_body lbody) args in
@@ -557,7 +557,7 @@ and mlt_env env r = let open GlobRef in match r with
   | ConstRef kn ->
      let cb = Environ.lookup_constant kn env in
      match cb.const_body with
-     | Undef _ | OpaqueDef _ | Primitive _ -> None
+     | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> None
      | Def l_body ->
         match lookup_typedef kn cb with
         | Some _ as o -> o
@@ -1121,7 +1121,7 @@ let extract_constant env kn cb =
     | (Logic,Default) -> warn_log (); Dterm (r, MLdummy Kprop, Tdummy Kprop)
     | (Info,TypeScheme) ->
         (match cb.const_body with
-          | Primitive _ | Undef _ -> warn_info (); mk_typ_ax ()
+          | Primitive _ | Symbol _ | Undef _ -> warn_info (); mk_typ_ax ()
           | Def c ->
              (match Structures.PrimitiveProjections.find_opt kn with
               | None -> mk_typ (get_body c)
@@ -1134,7 +1134,7 @@ let extract_constant env kn cb =
             else mk_typ_ax ())
     | (Info,Default) ->
         (match cb.const_body with
-          | Primitive _ | Undef _ -> warn_info (); mk_ax ()
+          | Primitive _ | Symbol _ | Undef _ -> warn_info (); mk_ax ()
           | Def c ->
              (match Structures.PrimitiveProjections.find_opt kn with
               | None -> mk_def (get_body c)
@@ -1161,7 +1161,7 @@ let extract_constant_spec env kn cb =
     | (Info, TypeScheme) ->
         let s,vl = type_sign_vl env sg typ in
         (match cb.const_body with
-          | Undef _ | OpaqueDef _ | Primitive _ -> Stype (r, vl, None)
+          | Undef _ | OpaqueDef _ | Primitive _ | Symbol _ -> Stype (r, vl, None)
           | Def body ->
               let db = db_from_sign s in
               let body = get_body body in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1410,6 +1410,7 @@ let is_opaque_constant c =
   | Declarations.Undef _ -> Opaque
   | Declarations.Def _ -> Transparent
   | Declarations.Primitive _ -> Opaque
+  | Declarations.Symbol _ -> Opaque
 
 let open_new_goal ~lemma build_proof sigma using_lemmas ref_ goal_name
     (gls_type, decompose_and_tac, nb_goal) =

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -159,7 +159,7 @@ let mkSTACK = function
 
 type cbv_infos = {
   env : Environ.env;
-  tab : (cbv_value, Empty.t) Declarations.constant_def KeyTable.t;
+  tab : (cbv_value, Empty.t, Declarations.rewrite_rule list) Declarations.constant_def KeyTable.t;
   reds : RedFlags.reds;
   sigma : Evd.evar_map
 }
@@ -542,6 +542,7 @@ and norm_head_ref k info env stack normt t =
           | RelKey _ | VarKey _ -> assert false
         in
         (PRIMITIVE(op,c,[||]),stack)
+      | Declarations.Symbol _ -> assert false
       | Declarations.OpaqueDef _ | Declarations.Undef _ ->
          debug_cbv (fun () -> Pp.(str "Not unfolding " ++ debug_pr_key normt));
          (VAL(0,make_constr_ref k normt t),stack)

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -159,7 +159,7 @@ let mkSTACK = function
 
 type cbv_infos = {
   env : Environ.env;
-  tab : (cbv_value, Empty.t, Declarations.rewrite_rule list) Declarations.constant_def KeyTable.t;
+  tab : (cbv_value, Empty.t, bool * Declarations.rewrite_rule list) Declarations.constant_def KeyTable.t;
   reds : RedFlags.reds;
   sigma : Evd.evar_map
 }
@@ -574,7 +574,7 @@ and norm_head_ref k info env stack normt t =
           | RelKey _ | VarKey _ -> assert false
         in
         (PRIMITIVE(op,c,[||]),stack)
-      | Declarations.Symbol r ->
+      | Declarations.Symbol (_, r) -> (* TODO *)
         let (_, u) = match normt with
           | ConstKey c -> c
           | RelKey _ | VarKey _ -> assert false
@@ -720,7 +720,7 @@ and cbv_value_cache info ref =
         Declarations.Def v
       with
       | Environ.NotEvaluableConst (Environ.IsPrimitive (_u,op)) -> Declarations.Primitive op
-      | Environ.NotEvaluableConst (Environ.HasRules r) -> Declarations.Symbol r
+      | Environ.NotEvaluableConst (Environ.HasRules (b, r)) -> Declarations.Symbol (b, r)
       | Not_found | Environ.NotEvaluableConst _ -> Declarations.Undef None
     in
     KeyTable.add info.tab ref v; v

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -769,18 +769,18 @@ and cbv_match_rigid_arg_pattern info tab p t =
   | PHFloat f, VAL(0, t') ->
     begin match kind t' with Float f' when Float64.equal f f' -> [], [] | _ -> raise PatternFailure end
   | PHLambda (ptys, pbod), LAM (nlam, ntys, _, env) ->
-    let tys = Array.of_list (List.rev_map (snd %> (cbv_stack_term info TOP env)) ntys) in
+    let tys = Array.map_of_list (snd %> (cbv_stack_term info TOP env)) ntys in
     if Array.length ptys <> Array.length tys then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (cbv_match_arg_pattern info env) ptys tys in
     let fs, fus = cbv_match_arg_pattern info env pbod t in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | PHProd (ptys, pbod), CBN (t', env) ->
     let ntys, body = Term.decompose_prod t' in
-    let tys = Array.map_of_list (snd %> (cbv_stack_term info TOP env)) ntys in
+    let tys = Array.of_list @@ List.rev_map (snd %> (cbv_stack_term info TOP env)) ntys in
     let na = Array.length tys in
     if Array.length ptys <> na then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (cbv_match_arg_pattern info env) ptys tys in
-    let funbody = LAM (na, ntys, body, env) in
+    let funbody = LAM (na, List.rev ntys, body, env) in
     let fs, fus = cbv_match_arg_pattern info env pbod funbody in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | (PHInd _ | PHConstr _ | PHInt _ | PHFloat _ | PHSort _ | PHSymbol _ | PHLambda _ | PHProd _), _ -> raise PatternFailure

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -57,7 +57,7 @@ val cbv_norm_term : cbv_infos -> cbv_value subs -> constr -> constr
 val norm_head : cbv_infos ->
   cbv_value subs -> constr -> cbv_stack -> cbv_value * cbv_stack
 val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.pattern_argument -> cbv_value -> cbv_value list * Univ.Level.t list
-val cbv_match_rigid_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.head_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
+val cbv_match_rigid_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.pattern_argument Declarations.head_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
 val cbv_apply_rule : cbv_infos -> cbv_value subs -> cbv_value list * Univ.Level.t list -> Declarations.pattern_elimination list -> cbv_stack -> (cbv_value list * Univ.Level.t list) * cbv_stack
 val cbv_apply_rules : cbv_infos -> cbv_value subs -> Univ.Instance.t -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * Univ.Level.t list * cbv_stack
 val apply_stack : cbv_infos -> constr -> cbv_stack -> constr

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -56,6 +56,10 @@ val cbv_stack_term : cbv_infos ->
 val cbv_norm_term : cbv_infos -> cbv_value subs -> constr -> constr
 val norm_head : cbv_infos ->
   cbv_value subs -> constr -> cbv_stack -> cbv_value * cbv_stack
+val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rewrite_arg_pattern -> cbv_value -> cbv_value list
+type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PECase of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array | PEProj of Projection.t
+val cbv_apply_rule : cbv_infos -> cbv_value subs -> types -> cbv_value list -> pattern_elimination list -> cbv_stack -> cbv_value list * cbv_stack
+val cbv_apply_rules : cbv_infos -> cbv_value subs -> types -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * cbv_stack
 val apply_stack : cbv_infos -> constr -> cbv_stack -> constr
 val cbv_norm_value : cbv_infos -> cbv_value -> constr
 

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -56,10 +56,10 @@ val cbv_stack_term : cbv_infos ->
 val cbv_norm_term : cbv_infos -> cbv_value subs -> constr -> constr
 val norm_head : cbv_infos ->
   cbv_value subs -> constr -> cbv_stack -> cbv_value * cbv_stack
-val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rewrite_arg_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
-val cbv_match_rigid_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rigid_arg_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
-val cbv_apply_rule : cbv_infos -> cbv_value subs -> types -> cbv_value list * Univ.Level.t list -> Declarations.pattern_elimination list -> cbv_stack -> (cbv_value list * Univ.Level.t list) * cbv_stack
-val cbv_apply_rules : cbv_infos -> cbv_value subs -> types -> Univ.Instance.t -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * Univ.Level.t list * cbv_stack
+val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.pattern_argument -> cbv_value -> cbv_value list * Univ.Level.t list
+val cbv_match_rigid_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.head_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
+val cbv_apply_rule : cbv_infos -> cbv_value subs -> cbv_value list * Univ.Level.t list -> Declarations.pattern_elimination list -> cbv_stack -> (cbv_value list * Univ.Level.t list) * cbv_stack
+val cbv_apply_rules : cbv_infos -> cbv_value subs -> Univ.Instance.t -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * Univ.Level.t list * cbv_stack
 val apply_stack : cbv_infos -> constr -> cbv_stack -> constr
 val cbv_norm_value : cbv_infos -> cbv_value -> constr
 

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -56,10 +56,9 @@ val cbv_stack_term : cbv_infos ->
 val cbv_norm_term : cbv_infos -> cbv_value subs -> constr -> constr
 val norm_head : cbv_infos ->
   cbv_value subs -> constr -> cbv_stack -> cbv_value * cbv_stack
-val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rewrite_arg_pattern -> cbv_value -> cbv_value list
-type pattern_elimination = PEApp of Declarations.rewrite_arg_pattern array | PECase of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array | PEProj of Projection.t
-val cbv_apply_rule : cbv_infos -> cbv_value subs -> types -> cbv_value list -> pattern_elimination list -> cbv_stack -> cbv_value list * cbv_stack
-val cbv_apply_rules : cbv_infos -> cbv_value subs -> types -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * cbv_stack
+val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rewrite_arg_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
+val cbv_apply_rule : cbv_infos -> cbv_value subs -> types -> cbv_value list * Univ.Level.t list -> Declarations.pattern_elimination list -> cbv_stack -> (cbv_value list * Univ.Level.t list) * cbv_stack
+val cbv_apply_rules : cbv_infos -> cbv_value subs -> types -> Univ.Instance.t -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * Univ.Level.t list * cbv_stack
 val apply_stack : cbv_infos -> constr -> cbv_stack -> constr
 val cbv_norm_value : cbv_infos -> cbv_value -> constr
 

--- a/pretyping/cbv.mli
+++ b/pretyping/cbv.mli
@@ -57,6 +57,7 @@ val cbv_norm_term : cbv_infos -> cbv_value subs -> constr -> constr
 val norm_head : cbv_infos ->
   cbv_value subs -> constr -> cbv_stack -> cbv_value * cbv_stack
 val cbv_match_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rewrite_arg_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
+val cbv_match_rigid_arg_pattern : cbv_infos -> cbv_value subs -> Declarations.rigid_arg_pattern -> cbv_value -> cbv_value list * Univ.Level.t list
 val cbv_apply_rule : cbv_infos -> cbv_value subs -> types -> cbv_value list * Univ.Level.t list -> Declarations.pattern_elimination list -> cbv_stack -> (cbv_value list * Univ.Level.t list) * cbv_stack
 val cbv_apply_rules : cbv_infos -> cbv_value subs -> types -> Univ.Instance.t -> Declarations.rewrite_rule list -> cbv_stack -> types * cbv_value list * Univ.Level.t list * cbv_stack
 val apply_stack : cbv_infos -> constr -> cbv_stack -> constr

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -673,6 +673,92 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
     let ctx = expand_branch env sigma u pms (ind, i) br in
     applist (it_mkLambda_or_LetIn (snd br) ctx, args)
 
+
+exception PatternFailure
+
+type pattern_elimination =
+  | PEApp     of Declarations.rewrite_arg_pattern array
+  | PECase    of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array
+  | PEProj    of Projection.t
+
+let rec eliminations_of_pattern acc = function
+  | Declarations.PConst _ -> acc
+  | Declarations.PApp (f, args) -> eliminations_of_pattern (PEApp args :: acc) f
+  | Declarations.PCase (ind, ret, c, brs) -> eliminations_of_pattern (PECase (ind, ret, brs) :: acc) c
+  | Declarations.PProj (p, c) -> eliminations_of_pattern (PEProj p :: acc) c
+let eliminations_of_pattern = eliminations_of_pattern []
+
+
+let rec simpl_match_arg_pattern sigma p t =
+  let open Declarations in
+  match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
+  | APHole, _ -> [t]
+  | APHoleIgnored, _ -> []
+  | APInd ind, Ind (ind', _) ->
+    if Ind.CanOrd.equal ind ind' then [] else raise PatternFailure
+  | APConstr constr, Construct (constr', _) ->
+    if Construct.CanOrd.equal constr constr' then [] else raise PatternFailure
+  | APInt i, Int i' ->
+    if Uint63.equal i i' then [] else raise PatternFailure
+  | APFloat f, Float f' ->
+    if Float64.equal f f' then [] else raise PatternFailure
+  | APApp (pf, pargs), App (f, args) ->
+      let np = Array.length pargs in
+      let na = Array.length args in
+      if np == na then
+        let fss = Array.map2 (simpl_match_arg_pattern sigma) pargs args in
+        let fs = simpl_match_arg_pattern sigma pf f in
+        fs @ List.concat (Array.to_list fss)
+      else if np < na then (* more real arguments *)
+        let remargs, usedargs = Array.chop (na - np) args in
+        let fss = Array.map2 (simpl_match_arg_pattern sigma) pargs usedargs in
+        let fs = simpl_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
+        fs @ List.concat (Array.to_list fss)
+      else (* more pattern arguments *)
+        let rempargs, usedpargs = Array.chop (np - na) pargs in
+        let fss = Array.map2 (simpl_match_arg_pattern sigma) usedpargs args in
+        let fs = simpl_match_arg_pattern sigma (APApp (pf, rempargs)) f in
+        fs @ List.concat (Array.to_list fss)
+  | _ -> raise PatternFailure
+
+let rec extract_n_stack args n s =
+  if n = 0 then List.rev args, s else
+  match Stack.decomp s with
+  | Some (arg, rest) -> extract_n_stack (arg :: args) (n-1) rest
+  | None -> raise PatternFailure
+
+let rec simpl_apply_rule env sigma fs es stk =
+  match [@ocaml.warning "-4"] es, stk with
+  | [], _ -> fs, stk
+  | PEApp pargs :: e, s ->
+      let np = Array.length pargs in
+      let pargs = Array.to_list pargs in
+      let args, s = extract_n_stack [] np s in
+      let fss = List.map2 (simpl_match_arg_pattern sigma) pargs args in
+      simpl_apply_rule env sigma (fs @ List.concat fss) e s
+  | PECase (pind, pret, pbrs) :: e, Stack.Case (ci, u, pms, p, iv, brs) :: s ->
+      if not @@ Ind.CanOrd.equal pind ci.ci_ind then raise PatternFailure;
+      let dummy = mkProp in
+      let (_, p, _, _, brs) = EConstr.expand_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
+      let fsret = simpl_match_arg_pattern sigma pret p in
+      let fsbrs = Array.map2 (simpl_match_arg_pattern sigma) pbrs brs in
+      simpl_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs)) e s
+  | PEProj proj :: e, Stack.Proj proj' :: s ->
+      if not @@ Projection.CanOrd.equal proj proj' then raise PatternFailure;
+      simpl_apply_rule env sigma fs e s
+  | _, _ -> raise PatternFailure
+
+
+let rec simpl_apply_rules info env r stk =
+  let open Declarations in
+  match r with
+  | [] -> raise PatternFailure
+  | r :: rs ->
+    try
+      let fs, stk = simpl_apply_rule info env [] (eliminations_of_pattern r.lhs_pat) stk in
+      EConstr.of_constr r.rhs, List.rev fs, stk
+    with PatternFailure -> simpl_apply_rules info env rs stk
+
 let whd_state_gen flags env sigma =
   let open Context.Named.Declaration in
   let rec whrec (x, stack) : state =
@@ -722,6 +808,15 @@ let whd_state_gen flags env sigma =
           (* Should not fail thanks to [check_native_args] *)
           let (before,a,after) = Option.get o in
           whrec (a,Stack.Primitive(p,const,before,kargs)::after)
+       | exception NotEvaluableConst (HasRules r) ->
+          begin try
+            let rhs, fs, stack = simpl_apply_rules env sigma r stack in
+            let rhsu = subst_instance_constr (EInstance.kind sigma u) rhs in
+            let rhs' = substl fs rhsu in
+            whrec (rhs', stack)
+          with PatternFailure ->
+            fold ()
+          end
        | exception NotEvaluableConst _ -> fold ()
       else fold ()
     | Proj (p, c) when CClosure.RedFlags.red_projection flags p ->

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -676,49 +676,46 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
 
 exception PatternFailure
 
-type pattern_elimination =
-  | PEApp     of Declarations.rewrite_arg_pattern array
-  | PECase    of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array
-  | PEProj    of Projection.t
-
 let rec eliminations_of_pattern acc = function
-  | Declarations.PConst _ -> acc
-  | Declarations.PApp (f, args) -> eliminations_of_pattern (PEApp args :: acc) f
-  | Declarations.PCase (ind, ret, c, brs) -> eliminations_of_pattern (PECase (ind, ret, brs) :: acc) c
-  | Declarations.PProj (p, c) -> eliminations_of_pattern (PEProj p :: acc) c
+  | Declarations.PConst (_, u) -> acc, u
+  | Declarations.PApp (f, args) -> eliminations_of_pattern (Declarations.PEApp args :: acc) f
+  | Declarations.PCase (ind, u, ret, c, brs) -> eliminations_of_pattern (Declarations.PECase (ind, u, ret, brs) :: acc) c
+  | Declarations.PProj (p, c) -> eliminations_of_pattern (Declarations.PEProj p :: acc) c
 let eliminations_of_pattern = eliminations_of_pattern []
 
+let match_universes pu u =
+  List.filter_with (Array.to_list pu) (Array.to_list (Univ.Instance.to_array u))
 
 let rec simpl_match_arg_pattern sigma p t =
   let open Declarations in
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
-  | APHole, _ -> [t]
-  | APHoleIgnored, _ -> []
-  | APInd ind, Ind (ind', _) ->
-    if Ind.CanOrd.equal ind ind' then [] else raise PatternFailure
-  | APConstr constr, Construct (constr', _) ->
-    if Construct.CanOrd.equal constr constr' then [] else raise PatternFailure
+  | APHole, _ -> [t], []
+  | APHoleIgnored, _ -> [], []
+  | APInd (ind, pu), Ind (ind', u) ->
+    if Ind.CanOrd.equal ind ind' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
+  | APConstr (constr, pu), Construct (constr', u) ->
+    if Construct.CanOrd.equal constr constr' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
   | APInt i, Int i' ->
-    if Uint63.equal i i' then [] else raise PatternFailure
+    if Uint63.equal i i' then [], [] else raise PatternFailure
   | APFloat f, Float f' ->
-    if Float64.equal f f' then [] else raise PatternFailure
+    if Float64.equal f f' then [], [] else raise PatternFailure
   | APApp (pf, pargs), App (f, args) ->
       let np = Array.length pargs in
       let na = Array.length args in
       if np == na then
-        let fss = Array.map2 (simpl_match_arg_pattern sigma) pargs args in
-        let fs = simpl_match_arg_pattern sigma pf f in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs args in
+        let fs, fus = simpl_match_arg_pattern sigma pf f in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else if np < na then (* more real arguments *)
         let remargs, usedargs = Array.chop (na - np) args in
-        let fss = Array.map2 (simpl_match_arg_pattern sigma) pargs usedargs in
-        let fs = simpl_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs usedargs in
+        let fs, fus = simpl_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else (* more pattern arguments *)
         let rempargs, usedpargs = Array.chop (np - na) pargs in
-        let fss = Array.map2 (simpl_match_arg_pattern sigma) usedpargs args in
-        let fs = simpl_match_arg_pattern sigma (APApp (pf, rempargs)) f in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) usedpargs args in
+        let fs, fus = simpl_match_arg_pattern sigma (APApp (pf, rempargs)) f in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
   | _ -> raise PatternFailure
 
 let rec extract_n_stack args n s =
@@ -727,37 +724,41 @@ let rec extract_n_stack args n s =
   | Some (arg, rest) -> extract_n_stack (arg :: args) (n-1) rest
   | None -> raise PatternFailure
 
-let rec simpl_apply_rule env sigma fs es stk =
+let rec simpl_apply_rule env sigma fsfus es stk =
   match [@ocaml.warning "-4"] es, stk with
-  | [], _ -> fs, stk
-  | PEApp pargs :: e, s ->
+  | [], _ -> fsfus, stk
+  | Declarations.PEApp pargs :: e, s ->
       let np = Array.length pargs in
       let pargs = Array.to_list pargs in
       let args, s = extract_n_stack [] np s in
-      let fss = List.map2 (simpl_match_arg_pattern sigma) pargs args in
-      simpl_apply_rule env sigma (fs @ List.concat fss) e s
-  | PECase (pind, pret, pbrs) :: e, Stack.Case (ci, u, pms, p, iv, brs) :: s ->
+      let fs, fus = fsfus in
+      let fss, fuss = List.split @@ List.map2 (simpl_match_arg_pattern sigma) pargs args in
+      simpl_apply_rule env sigma (fs @ List.concat fss, fus @ List.concat fuss) e s
+  | Declarations.PECase (pind, pu, pret, pbrs) :: e, Stack.Case (ci, u, pms, p, iv, brs) :: s ->
       if not @@ Ind.CanOrd.equal pind ci.ci_ind then raise PatternFailure;
       let dummy = mkProp in
+      let fs, fus = fsfus in
+      let fuus = match_universes pu (EInstance.kind sigma u) in
       let (_, p, _, _, brs) = EConstr.expand_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
-      let fsret = simpl_match_arg_pattern sigma pret p in
-      let fsbrs = Array.map2 (simpl_match_arg_pattern sigma) pbrs brs in
-      simpl_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs)) e s
-  | PEProj proj :: e, Stack.Proj proj' :: s ->
+      let fsret, fusret = simpl_match_arg_pattern sigma pret p in
+      let fsbrs, fusbrs = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pbrs brs in
+      simpl_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs), fus @ fuus @ fusret @ List.concat (Array.to_list fusbrs)) e s
+  | Declarations.PEProj proj :: e, Stack.Proj proj' :: s ->
       if not @@ Projection.CanOrd.equal proj proj' then raise PatternFailure;
-      simpl_apply_rule env sigma fs e s
+      simpl_apply_rule env sigma fsfus e s
   | _, _ -> raise PatternFailure
 
 
-let rec simpl_apply_rules info env r stk =
+let rec simpl_apply_rules info env u r stk =
   let open Declarations in
   match r with
   | [] -> raise PatternFailure
   | r :: rs ->
     try
-      let fs, stk = simpl_apply_rule info env [] (eliminations_of_pattern r.lhs_pat) stk in
-      EConstr.of_constr r.rhs, List.rev fs, stk
-    with PatternFailure -> simpl_apply_rules info env rs stk
+      let elims, pu = eliminations_of_pattern r.lhs_pat in
+      let (fs, fus), stk = simpl_apply_rule info env ([], []) elims stk in
+      EConstr.of_constr r.rhs, fs, match_universes pu u @ fus, stk
+    with PatternFailure -> simpl_apply_rules info env u rs stk
 
 let whd_state_gen flags env sigma =
   let open Context.Named.Declaration in
@@ -810,8 +811,9 @@ let whd_state_gen flags env sigma =
           whrec (a,Stack.Primitive(p,const,before,kargs)::after)
        | exception NotEvaluableConst (HasRules r) ->
           begin try
-            let rhs, fs, stack = simpl_apply_rules env sigma r stack in
-            let rhsu = subst_instance_constr (EInstance.kind sigma u) rhs in
+            let rhs, fs, fus, stack = simpl_apply_rules env sigma u' r stack in
+            let usubst = Univ.Instance.of_array (Array.of_list fus) in
+            let rhsu = subst_instance_constr usubst rhs in
             let rhs' = substl fs rhsu in
             whrec (rhs', stack)
           with PatternFailure ->

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -677,7 +677,7 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
 exception PatternFailure
 
 let rec eliminations_of_pattern acc = function
-  | Declarations.PConst (_, u) -> acc, u
+  | Declarations.PHead (_, u) -> acc, u
   | Declarations.PApp (f, args) -> eliminations_of_pattern (Declarations.PEApp args :: acc) f
   | Declarations.PCase (ind, u, ret, c, brs) -> eliminations_of_pattern (Declarations.PECase (ind, u, ret, brs) :: acc) c
   | Declarations.PProj (p, c) -> eliminations_of_pattern (Declarations.PEProj p :: acc) c
@@ -710,16 +710,16 @@ and match_sort (ps, pu) s =
 
 and simpl_match_rigid_arg_pattern sigma p t =
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
-  | APInd (ind, pu), Ind (ind', u) ->
+  | APHead PHInd (ind, pu), Ind (ind', u) ->
     if Ind.CanOrd.equal ind ind' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APConstr (constr, pu), Construct (constr', u) ->
+  | APHead PHConstr (constr, pu), Construct (constr', u) ->
     if Construct.CanOrd.equal constr constr' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APSort ps, Sort s -> match_sort ps (ESorts.kind sigma s)
-  | APSymbol (c, pu), Const (c', u) ->
+  | APHead PHSort ps, Sort s -> match_sort ps (ESorts.kind sigma s)
+  | APHead PHSymbol (c, pu), Const (c', u) ->
     if Constant.CanOrd.equal c c' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APInt i, Int i' ->
+  | APHead PHInt i, Int i' ->
     if Uint63.equal i i' then [], [] else raise PatternFailure
-  | APFloat f, Float f' ->
+  | APHead PHFloat f, Float f' ->
     if Float64.equal f f' then [], [] else raise PatternFailure
   | APApp (pf, pargs), App (f, args) ->
       let np = Array.length pargs in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -747,18 +747,18 @@ and simpl_match_rigid_arg_pattern whrec env sigma p t =
     if Float64.equal f f' then [], [] else raise PatternFailure
   | PHLambda (ptys, pbod), _ ->
     let ntys, body = EConstr.decompose_lambda sigma t in
-    let tys = Array.map_of_list snd ntys in
+    let tys = Array.of_list @@ List.rev_map snd ntys in
     if Array.length ptys <> Array.length tys then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern whrec env sigma) ptys tys in
     let fs, fus = simpl_match_arg_pattern whrec env sigma pbod t in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | PHProd (ptys, pbod), _ ->
     let ntys, body = EConstr.decompose_prod sigma t in
-    let tys = Array.map_of_list snd ntys in
+    let tys = Array.of_list @@ List.rev_map snd ntys in
     let na = Array.length tys in
     if Array.length ptys <> na then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern whrec env sigma) ptys tys in
-    let funbody = EConstr.it_mkProd body ntys in
+    let funbody = EConstr.it_mkLambda body ntys in
     let fs, fus = simpl_match_arg_pattern whrec env sigma pbod funbody in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | (PHInd _ | PHConstr _ | PHSort _ | PHSymbol _ | PHInt _ | PHFloat _), _ -> raise PatternFailure

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -685,16 +685,38 @@ let eliminations_of_pattern = eliminations_of_pattern []
 
 let match_universes pu u =
   List.filter_with (Array.to_list pu) (Array.to_list (Univ.Instance.to_array u))
+let match_euniverses sigma pu u = match_universes pu (EInstance.kind sigma u)
 
 let rec simpl_match_arg_pattern sigma p t =
   let open Declarations in
+  match p with
+  | APHole -> [t], []
+  | APHoleIgnored -> [], []
+  | APRigid p -> simpl_match_rigid_arg_pattern sigma p t
+
+and match_sort (ps, pu) s =
+  let open Sorts in
+  match [@ocaml.warning "-4"] ps, s with
+  | InProp, Prop -> [], []
+  | InSProp, SProp -> [], []
+  | InSet, Set -> [], []
+  | InType, Type u ->
+      assert (Array.length pu = 1);
+      if not pu.(0) then [], []
+      else if not (Univ.Universe.is_level u) then assert false
+      else [], [Option.get (Univ.Universe.level u)]
+  | InQSort, _ -> assert false
+  | (InProp | InSProp | InSet | InType), _ -> raise PatternFailure
+
+and simpl_match_rigid_arg_pattern sigma p t =
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
-  | APHole, _ -> [t], []
-  | APHoleIgnored, _ -> [], []
   | APInd (ind, pu), Ind (ind', u) ->
-    if Ind.CanOrd.equal ind ind' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
+    if Ind.CanOrd.equal ind ind' then [], match_euniverses sigma pu u else raise PatternFailure
   | APConstr (constr, pu), Construct (constr', u) ->
-    if Construct.CanOrd.equal constr constr' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
+    if Construct.CanOrd.equal constr constr' then [], match_euniverses sigma pu u else raise PatternFailure
+  | APSort ps, Sort s -> match_sort ps (ESorts.kind sigma s)
+  | APSymbol (c, pu), Const (c', u) ->
+    if Constant.CanOrd.equal c c' then [], match_euniverses sigma pu u else raise PatternFailure
   | APInt i, Int i' ->
     if Uint63.equal i i' then [], [] else raise PatternFailure
   | APFloat f, Float f' ->
@@ -704,17 +726,17 @@ let rec simpl_match_arg_pattern sigma p t =
       let na = Array.length args in
       if np == na then
         let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs args in
-        let fs, fus = simpl_match_arg_pattern sigma pf f in
+        let fs, fus = simpl_match_rigid_arg_pattern sigma pf f in
         fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else if np < na then (* more real arguments *)
         let remargs, usedargs = Array.chop (na - np) args in
         let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs usedargs in
-        let fs, fus = simpl_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
+        let fs, fus = simpl_match_rigid_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
         fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else (* more pattern arguments *)
         let rempargs, usedpargs = Array.chop (np - na) pargs in
         let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) usedpargs args in
-        let fs, fus = simpl_match_arg_pattern sigma (APApp (pf, rempargs)) f in
+        let fs, fus = simpl_match_rigid_arg_pattern sigma (APApp (pf, rempargs)) f in
         fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
   | _ -> raise PatternFailure
 
@@ -738,7 +760,7 @@ let rec simpl_apply_rule env sigma fsfus es stk =
       if not @@ Ind.CanOrd.equal pind ci.ci_ind then raise PatternFailure;
       let dummy = mkProp in
       let fs, fus = fsfus in
-      let fuus = match_universes pu (EInstance.kind sigma u) in
+      let fuus = match_euniverses sigma pu u in
       let (_, p, _, _, brs) = EConstr.expand_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
       let fsret, fusret = simpl_match_arg_pattern sigma pret p in
       let fsbrs, fusbrs = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pbrs brs in
@@ -749,16 +771,16 @@ let rec simpl_apply_rule env sigma fsfus es stk =
   | _, _ -> raise PatternFailure
 
 
-let rec simpl_apply_rules info env u r stk =
+let rec simpl_apply_rules env sigma u r stk =
   let open Declarations in
   match r with
   | [] -> raise PatternFailure
   | r :: rs ->
     try
       let elims, pu = eliminations_of_pattern r.lhs_pat in
-      let (fs, fus), stk = simpl_apply_rule info env ([], []) elims stk in
-      EConstr.of_constr r.rhs, fs, match_universes pu u @ fus, stk
-    with PatternFailure -> simpl_apply_rules info env u rs stk
+      let (fs, fus), stk = simpl_apply_rule env sigma ([], []) elims stk in
+      EConstr.of_constr r.rhs, fs, match_euniverses sigma pu u @ fus, stk
+    with PatternFailure -> simpl_apply_rules env sigma u rs stk
 
 let whd_state_gen flags env sigma =
   let open Context.Named.Declaration in
@@ -811,7 +833,7 @@ let whd_state_gen flags env sigma =
           whrec (a,Stack.Primitive(p,const,before,kargs)::after)
        | exception NotEvaluableConst (HasRules r) ->
           begin try
-            let rhs, fs, fus, stack = simpl_apply_rules env sigma u' r stack in
+            let rhs, fs, fus, stack = simpl_apply_rules env sigma u r stack in
             let usubst = Univ.Instance.of_array (Array.of_list fus) in
             let rhsu = subst_instance_constr usubst rhs in
             let rhs' = substl fs rhsu in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -676,23 +676,40 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
 
 exception PatternFailure
 
-let rec eliminations_of_pattern acc = function
-  | Declarations.PHead (_, u) -> acc, u
-  | Declarations.PApp (f, args) -> eliminations_of_pattern (Declarations.PEApp args :: acc) f
-  | Declarations.PCase (ind, u, ret, c, brs) -> eliminations_of_pattern (Declarations.PECase (ind, u, ret, brs) :: acc) c
-  | Declarations.PProj (p, c) -> eliminations_of_pattern (Declarations.PEProj p :: acc) c
+let rec eliminations_of_rigid_pattern acc =
+  let open Declarations in
+  function
+  | APHead h -> h, acc
+  | APApp (f, args) -> eliminations_of_rigid_pattern (PEApp (Array.map pattern_arg_of_arg_pattern args) :: acc) f
+and pattern_arg_of_arg_pattern = function
+  | APHole -> EHole
+  | APHoleIgnored -> EHoleIgnored
+  | APRigid p -> ERigid (eliminations_of_rigid_pattern [] p)
+
+let rec eliminations_of_pattern acc =
+  let open Declarations in
+  function
+  | PHead (_, u) -> acc, u
+  | PApp (f, args) -> eliminations_of_pattern (PEApp (Array.map pattern_arg_of_arg_pattern args) :: acc) f
+  | PCase (ind, u, ret, c, brs) ->
+      eliminations_of_pattern (PECase (ind, u, pattern_arg_of_arg_pattern ret, Array.map pattern_arg_of_arg_pattern brs) :: acc) c
+  | PProj (p, c) -> eliminations_of_pattern (PEProj p :: acc) c
 let eliminations_of_pattern = eliminations_of_pattern []
 
 let match_universes pu u =
   List.filter_with (Array.to_list pu) (Array.to_list (Univ.Instance.to_array u))
 let match_euniverses sigma pu u = match_universes pu (EInstance.kind sigma u)
 
-let rec simpl_match_arg_pattern sigma p t =
+let rec simpl_match_arg_pattern whrec env sigma p t =
   let open Declarations in
   match p with
-  | APHole -> [t], []
-  | APHoleIgnored -> [], []
-  | APRigid p -> simpl_match_rigid_arg_pattern sigma p t
+  | EHole -> [t], []
+  | EHoleIgnored -> [], []
+  | ERigid (ph, es) ->
+      let t, stk = whrec (t, Stack.empty) in
+      let fsfus = simpl_match_rigid_arg_pattern sigma ph t in
+      let fsfus, stk = simpl_apply_rule whrec env sigma fsfus es stk in
+      if Stack.is_empty stk then fsfus else raise PatternFailure
 
 and match_sort (ps, pu) s =
   let open Sorts in
@@ -710,43 +727,26 @@ and match_sort (ps, pu) s =
 
 and simpl_match_rigid_arg_pattern sigma p t =
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
-  | APHead PHInd (ind, pu), Ind (ind', u) ->
+  | PHInd (ind, pu), Ind (ind', u) ->
     if Ind.CanOrd.equal ind ind' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APHead PHConstr (constr, pu), Construct (constr', u) ->
+  | PHConstr (constr, pu), Construct (constr', u) ->
     if Construct.CanOrd.equal constr constr' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APHead PHSort ps, Sort s -> match_sort ps (ESorts.kind sigma s)
-  | APHead PHSymbol (c, pu), Const (c', u) ->
+  | PHSort ps, Sort s -> match_sort ps (ESorts.kind sigma s)
+  | PHSymbol (c, pu), Const (c', u) ->
     if Constant.CanOrd.equal c c' then [], match_euniverses sigma pu u else raise PatternFailure
-  | APHead PHInt i, Int i' ->
+  | PHInt i, Int i' ->
     if Uint63.equal i i' then [], [] else raise PatternFailure
-  | APHead PHFloat f, Float f' ->
+  | PHFloat f, Float f' ->
     if Float64.equal f f' then [], [] else raise PatternFailure
-  | APApp (pf, pargs), App (f, args) ->
-      let np = Array.length pargs in
-      let na = Array.length args in
-      if np == na then
-        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs args in
-        let fs, fus = simpl_match_rigid_arg_pattern sigma pf f in
-        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
-      else if np < na then (* more real arguments *)
-        let remargs, usedargs = Array.chop (na - np) args in
-        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pargs usedargs in
-        let fs, fus = simpl_match_rigid_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
-        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
-      else (* more pattern arguments *)
-        let rempargs, usedpargs = Array.chop (np - na) pargs in
-        let fss, fuss = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) usedpargs args in
-        let fs, fus = simpl_match_rigid_arg_pattern sigma (APApp (pf, rempargs)) f in
-        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
-  | _ -> raise PatternFailure
+  | (PHInd _ | PHConstr _ | PHSort _ | PHSymbol _ | PHInt _ | PHFloat _), _ -> raise PatternFailure
 
-let rec extract_n_stack args n s =
+and extract_n_stack args n s =
   if n = 0 then List.rev args, s else
   match Stack.decomp s with
   | Some (arg, rest) -> extract_n_stack (arg :: args) (n-1) rest
   | None -> raise PatternFailure
 
-let rec simpl_apply_rule env sigma fsfus es stk =
+and simpl_apply_rule whrec env sigma fsfus es stk =
   match [@ocaml.warning "-4"] es, stk with
   | [], _ -> fsfus, stk
   | Declarations.PEApp pargs :: e, s ->
@@ -754,33 +754,33 @@ let rec simpl_apply_rule env sigma fsfus es stk =
       let pargs = Array.to_list pargs in
       let args, s = extract_n_stack [] np s in
       let fs, fus = fsfus in
-      let fss, fuss = List.split @@ List.map2 (simpl_match_arg_pattern sigma) pargs args in
-      simpl_apply_rule env sigma (fs @ List.concat fss, fus @ List.concat fuss) e s
+      let fss, fuss = List.split @@ List.map2 (simpl_match_arg_pattern whrec env sigma) pargs args in
+      simpl_apply_rule whrec env sigma (fs @ List.concat fss, fus @ List.concat fuss) e s
   | Declarations.PECase (pind, pu, pret, pbrs) :: e, Stack.Case (ci, u, pms, p, iv, brs) :: s ->
       if not @@ Ind.CanOrd.equal pind ci.ci_ind then raise PatternFailure;
       let dummy = mkProp in
       let fs, fus = fsfus in
       let fuus = match_euniverses sigma pu u in
       let (_, p, _, _, brs) = EConstr.expand_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
-      let fsret, fusret = simpl_match_arg_pattern sigma pret p in
-      let fsbrs, fusbrs = Array.split @@ Array.map2 (simpl_match_arg_pattern sigma) pbrs brs in
-      simpl_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs), fus @ fuus @ fusret @ List.concat (Array.to_list fusbrs)) e s
+      let fsret, fusret = simpl_match_arg_pattern whrec env sigma pret p in
+      let fsbrs, fusbrs = Array.split @@ Array.map2 (simpl_match_arg_pattern whrec env sigma) pbrs brs in
+      simpl_apply_rule whrec env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs), fus @ fuus @ fusret @ List.concat (Array.to_list fusbrs)) e s
   | Declarations.PEProj proj :: e, Stack.Proj proj' :: s ->
       if not @@ Projection.CanOrd.equal proj proj' then raise PatternFailure;
-      simpl_apply_rule env sigma fsfus e s
+      simpl_apply_rule whrec env sigma fsfus e s
   | _, _ -> raise PatternFailure
 
 
-let rec simpl_apply_rules env sigma u r stk =
+let rec simpl_apply_rules whrec env sigma u r stk =
   let open Declarations in
   match r with
   | [] -> raise PatternFailure
   | r :: rs ->
     try
       let elims, pu = eliminations_of_pattern r.lhs_pat in
-      let (fs, fus), stk = simpl_apply_rule env sigma ([], []) elims stk in
+      let (fs, fus), stk = simpl_apply_rule whrec env sigma ([], []) elims stk in
       EConstr.of_constr r.rhs, fs, match_euniverses sigma pu u @ fus, stk
-    with PatternFailure -> simpl_apply_rules env sigma u rs stk
+    with PatternFailure -> simpl_apply_rules whrec env sigma u rs stk
 
 let whd_state_gen flags env sigma =
   let open Context.Named.Declaration in
@@ -833,7 +833,7 @@ let whd_state_gen flags env sigma =
           whrec (a,Stack.Primitive(p,const,before,kargs)::after)
        | exception NotEvaluableConst (HasRules r) ->
           begin try
-            let rhs, fs, fus, stack = simpl_apply_rules env sigma u r stack in
+            let rhs, fs, fus, stack = simpl_apply_rules whrec env sigma u r stack in
             let usubst = Univ.Instance.of_array (Array.of_list fus) in
             let rhsu = subst_instance_constr usubst rhs in
             let rhs' = substl fs rhsu in

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -798,6 +798,9 @@ and whd_simpl_stack env sigma =
             whd_const cst env sigma (applist (x, stack)), []
           with Redelimination -> s')
 
+      | Const (cst, _) when is_symbol env cst ->
+          whd_const cst env sigma (applist s'), []
+
       | _ ->
         match match_eval_ref env sigma x stack with
         | Some (ref, u) ->

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -634,18 +634,18 @@ and cbn_match_rigid_arg_pattern whrec env sigma p t =
     if Float64.equal f f' then [], [] else raise PatternFailure
   | PHLambda (ptys, pbod), _ ->
     let ntys, body = EConstr.decompose_lambda sigma t in
-    let tys = Array.map_of_list snd ntys in
+    let tys = Array.of_list @@ List.rev_map snd ntys in
     if Array.length ptys <> Array.length tys then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern whrec env sigma) ptys tys in
     let fs, fus = cbn_match_arg_pattern whrec env sigma pbod t in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | PHProd (ptys, pbod), _ ->
     let ntys, body = EConstr.decompose_prod sigma t in
-    let tys = Array.map_of_list snd ntys in
+    let tys = Array.of_list @@ List.rev_map snd ntys in
     let na = Array.length tys in
     if Array.length ptys <> na then raise PatternFailure;
     let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern whrec env sigma) ptys tys in
-    let funbody = EConstr.it_mkProd body ntys in
+    let funbody = EConstr.it_mkLambda body ntys in
     let fs, fus = cbn_match_arg_pattern whrec env sigma pbod funbody in
     (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | (PHInd _ | PHConstr _ | PHInt _ | PHFloat _ | PHSort _ | PHSymbol _), _ -> raise PatternFailure

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -561,49 +561,46 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
 
 exception PatternFailure
 
-type pattern_elimination =
-  | PEApp     of Declarations.rewrite_arg_pattern array
-  | PECase    of inductive * Declarations.rewrite_arg_pattern * Declarations.rewrite_arg_pattern array
-  | PEProj    of Projection.t
-
 let rec eliminations_of_pattern acc = function
-  | Declarations.PConst _ -> acc
-  | Declarations.PApp (f, args) -> eliminations_of_pattern (PEApp args :: acc) f
-  | Declarations.PCase (ind, ret, c, brs) -> eliminations_of_pattern (PECase (ind, ret, brs) :: acc) c
-  | Declarations.PProj (p, c) -> eliminations_of_pattern (PEProj p :: acc) c
+  | Declarations.PConst (_, u) -> acc, u
+  | Declarations.PApp (f, args) -> eliminations_of_pattern (Declarations.PEApp args :: acc) f
+  | Declarations.PCase (ind, u, ret, c, brs) -> eliminations_of_pattern (Declarations.PECase (ind, u, ret, brs) :: acc) c
+  | Declarations.PProj (p, c) -> eliminations_of_pattern (Declarations.PEProj p :: acc) c
 let eliminations_of_pattern = eliminations_of_pattern []
 
+let match_universes pu u =
+  List.filter_with (Array.to_list pu) (Array.to_list (Univ.Instance.to_array u))
 
 let rec cbn_match_arg_pattern sigma p t =
   let open Declarations in
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
-  | APHole, _ -> [t]
-  | APHoleIgnored, _ -> []
-  | APInd ind, Ind (ind', _) ->
-    if Ind.CanOrd.equal ind ind' then [] else raise PatternFailure
-  | APConstr constr, Construct (constr', _) ->
-    if Construct.CanOrd.equal constr constr' then [] else raise PatternFailure
+  | APHole, _ -> [t], []
+  | APHoleIgnored, _ -> [], []
+  | APInd (ind, pu), Ind (ind', u) ->
+    if Ind.CanOrd.equal ind ind' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
+  | APConstr (constr, pu), Construct (constr', u) ->
+    if Construct.CanOrd.equal constr constr' then [], match_universes pu (EInstance.kind sigma u) else raise PatternFailure
   | APInt i, Int i' ->
-    if Uint63.equal i i' then [] else raise PatternFailure
+    if Uint63.equal i i' then [], [] else raise PatternFailure
   | APFloat f, Float f' ->
-    if Float64.equal f f' then [] else raise PatternFailure
+    if Float64.equal f f' then [], [] else raise PatternFailure
   | APApp (pf, pargs), App (f, args) ->
       let np = Array.length pargs in
       let na = Array.length args in
       if np == na then
-        let fss = Array.map2 (cbn_match_arg_pattern sigma) pargs args in
-        let fs = cbn_match_arg_pattern sigma pf f in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern sigma) pargs args in
+        let fs, fus = cbn_match_arg_pattern sigma pf f in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else if np < na then (* more real arguments *)
         let remargs, usedargs = Array.chop (na - np) args in
-        let fss = Array.map2 (cbn_match_arg_pattern sigma) pargs usedargs in
-        let fs = cbn_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern sigma) pargs usedargs in
+        let fs, fus = cbn_match_arg_pattern sigma pf (EConstr.of_kind (App (f, remargs))) in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
       else (* more pattern arguments *)
         let rempargs, usedpargs = Array.chop (np - na) pargs in
-        let fss = Array.map2 (cbn_match_arg_pattern sigma) usedpargs args in
-        let fs = cbn_match_arg_pattern sigma (APApp (pf, rempargs)) f in
-        fs @ List.concat (Array.to_list fss)
+        let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern sigma) usedpargs args in
+        let fs, fus = cbn_match_arg_pattern sigma (APApp (pf, rempargs)) f in
+        fs @ List.concat (Array.to_list fss), fus @ List.concat (Array.to_list fuss)
   | _ -> raise PatternFailure
 
 let rec extract_n_stack args n s =
@@ -612,37 +609,41 @@ let rec extract_n_stack args n s =
   | Some (arg, rest) -> extract_n_stack (arg :: args) (n-1) rest
   | None -> raise PatternFailure
 
-let rec cbn_apply_rule env sigma fs es stk =
+let rec cbn_apply_rule env sigma fsfus es stk =
   match [@ocaml.warning "-4"] es, stk with
-  | [], _ -> fs, stk
-  | PEApp pargs :: e, s ->
+  | [], _ -> fsfus, stk
+  | Declarations.PEApp pargs :: e, s ->
       let np = Array.length pargs in
       let pargs = Array.to_list pargs in
       let args, s = extract_n_stack [] np s in
-      let fss = List.map2 (cbn_match_arg_pattern sigma) pargs args in
-      cbn_apply_rule env sigma (fs @ List.concat fss) e s
-  | PECase (pind, pret, pbrs) :: e, Stack.Case ((ci, u, pms, p, iv, brs), cst_l) :: s ->
+      let fs, fus = fsfus in
+      let fss, fuss = List.split @@ List.map2 (cbn_match_arg_pattern sigma) pargs args in
+      cbn_apply_rule env sigma (fs @ List.concat fss, fus @ List.concat fuss) e s
+  | Declarations.PECase (pind, pu, pret, pbrs) :: e, Stack.Case ((ci, u, pms, p, iv, brs), cst_l) :: s ->
       if not @@ Ind.CanOrd.equal pind ci.ci_ind then raise PatternFailure;
       let dummy = mkProp in
+      let fs, fus = fsfus in
+      let fuus = match_universes pu (EInstance.kind sigma u) in
       let (_, p, _, _, brs) = EConstr.expand_case env sigma (ci, u, pms, p, NoInvert, dummy, brs) in
-      let fsret = cbn_match_arg_pattern sigma pret p in
-      let fsbrs = Array.map2 (cbn_match_arg_pattern sigma) pbrs brs in
-      cbn_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs)) e s
-  | PEProj proj :: e, Stack.Proj (proj', cst_l') :: s ->
+      let fsret, fusret = cbn_match_arg_pattern sigma pret p in
+      let fsbrs, fusbrs = Array.split @@ Array.map2 (cbn_match_arg_pattern sigma) pbrs brs in
+      cbn_apply_rule env sigma (fs @ fsret @ List.concat (Array.to_list fsbrs), fus @ fuus @ fusret @ List.concat (Array.to_list fusbrs)) e s
+  | Declarations.PEProj proj :: e, Stack.Proj (proj', cst_l') :: s ->
       if not @@ Projection.CanOrd.equal proj proj' then raise PatternFailure;
-      cbn_apply_rule env sigma fs e s
+      cbn_apply_rule env sigma fsfus e s
   | _, _ -> raise PatternFailure
 
 
-let rec cbn_apply_rules info env r stk =
+let rec cbn_apply_rules info env u r stk =
   let open Declarations in
   match r with
   | [] -> raise PatternFailure
   | r :: rs ->
     try
-      let fs, stk = cbn_apply_rule info env [] (eliminations_of_pattern r.lhs_pat) stk in
-      EConstr.of_constr r.rhs, List.rev fs, stk
-    with PatternFailure -> cbn_apply_rules info env rs stk
+      let elims, pu = eliminations_of_pattern r.lhs_pat in
+      let (fs, fus), stk = cbn_apply_rule info env ([], []) elims stk in
+      EConstr.of_constr r.rhs, fs, match_universes pu u @ fus, stk
+    with PatternFailure -> cbn_apply_rules info env u rs stk
 
 
 
@@ -753,8 +754,9 @@ let whd_state_gen ?csts flags env sigma =
           whrec Cst_stack.empty (a,Stack.Primitive(p,const,before,kargs,cst_l)::after)
        | exception NotEvaluableConst (HasRules r) ->
           begin try
-            let rhs, fs, stack = cbn_apply_rules env sigma r stack in
-            let rhsu = subst_instance_constr (EInstance.kind sigma u) rhs in
+            let rhs, fs, fus, stack = cbn_apply_rules env sigma u' r stack in
+            let usubst = Univ.Instance.of_array (Array.of_list fus) in
+            let rhsu = subst_instance_constr usubst rhs in
             let rhs' = substl fs rhsu in
             whrec Cst_stack.empty (rhs', stack)
           with PatternFailure ->

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -561,10 +561,17 @@ let apply_branch env sigma (ind, i) args (ci, u, pms, iv, r, lf) =
 
 exception PatternFailure
 
-let rec eliminations_of_rigid_pattern acc =
+let rec epattern_head_of_pattern_head =
   let open Declarations in
   function
-  | APHead h -> h, acc
+  | PHLambda (p1, p2) -> PHLambda (Array.map pattern_arg_of_arg_pattern p1, pattern_arg_of_arg_pattern p2)
+  | PHProd (p1, p2) -> PHProd (Array.map pattern_arg_of_arg_pattern p1, pattern_arg_of_arg_pattern p2)
+  | PHSort _ | PHSymbol _ | PHInd _ | PHConstr _ | PHInt _ | PHFloat _ as p -> p
+
+and eliminations_of_rigid_pattern acc =
+  let open Declarations in
+  function
+  | APHead h -> epattern_head_of_pattern_head h, acc
   | APApp (f, args) -> eliminations_of_rigid_pattern (PEApp (Array.map pattern_arg_of_arg_pattern args) :: acc) f
 and pattern_arg_of_arg_pattern = function
   | APHole -> EHole
@@ -592,7 +599,7 @@ let rec cbn_match_arg_pattern whrec env sigma p t =
   | EHoleIgnored -> [], []
   | ERigid (ph, es) ->
       let (t, stk), _ = whrec Cst_stack.empty (t, Stack.empty) in
-      let fsfus = cbn_match_rigid_arg_pattern sigma ph t in
+      let fsfus = cbn_match_rigid_arg_pattern whrec env sigma ph t in
       let fsfus, stk = cbn_apply_rule whrec env sigma fsfus es stk in
       match stk with
       | [] -> fsfus
@@ -612,7 +619,7 @@ and match_sort (ps, pu) s =
   | InQSort, _ -> assert false
   | (InProp | InSProp | InSet | InType), _ -> raise PatternFailure
 
-and cbn_match_rigid_arg_pattern sigma p t =
+and cbn_match_rigid_arg_pattern whrec env sigma p t =
   match [@ocaml.warning "-4"] p, EConstr.kind sigma t with
   | PHInd (ind, pu), Ind (ind', u) ->
     if Ind.CanOrd.equal ind ind' then [], match_euniverses sigma pu u else raise PatternFailure
@@ -625,6 +632,22 @@ and cbn_match_rigid_arg_pattern sigma p t =
     if Uint63.equal i i' then [], [] else raise PatternFailure
   | PHFloat f, Float f' ->
     if Float64.equal f f' then [], [] else raise PatternFailure
+  | PHLambda (ptys, pbod), _ ->
+    let ntys, body = EConstr.decompose_lambda sigma t in
+    let tys = Array.map_of_list snd ntys in
+    if Array.length ptys <> Array.length tys then raise PatternFailure;
+    let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern whrec env sigma) ptys tys in
+    let fs, fus = cbn_match_arg_pattern whrec env sigma pbod t in
+    (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
+  | PHProd (ptys, pbod), _ ->
+    let ntys, body = EConstr.decompose_prod sigma t in
+    let tys = Array.map_of_list snd ntys in
+    let na = Array.length tys in
+    if Array.length ptys <> na then raise PatternFailure;
+    let fss, fuss = Array.split @@ Array.map2 (cbn_match_arg_pattern whrec env sigma) ptys tys in
+    let funbody = EConstr.it_mkProd body ntys in
+    let fs, fus = cbn_match_arg_pattern whrec env sigma pbod funbody in
+    (List.concat (Array.to_list fss) @ fs, List.concat (Array.to_list fuss) @ fus)
   | (PHInd _ | PHConstr _ | PHInt _ | PHFloat _ | PHSort _ | PHSymbol _), _ -> raise PatternFailure
 
 and extract_n_stack args n s =

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -1,30 +1,32 @@
 Inductive rewrite {A : Type} (a: A) (b: A) := rewrite_intro.
-Notation "a == b" := (rewrite_intro a b) (at level 80).
+Notation "a ==> b" := (rewrite_intro a b) (at level 80).
 
 Axiom pplus : nat -> nat -> nat.
 Notation "a ++ b" := (pplus a b).
 
-Definition addn0 := fun n => n ++ 0 == n.
-Definition addnS := fun n n' => n ++ S n' == S (n ++ n').
-Definition add0n := fun n => 0 ++ n == n.
-Definition addSn := fun n n' => S n ++ n' == S (n ++ n').
+Definition addn0 := fun n => n ++ 0 ==> n.
+Definition addnS := fun n n' => n ++ S n' ==> S (n ++ n').
+Definition add0n := fun n => 0 ++ n ==> n.
+Definition addSn := fun n n' => S n ++ n' ==> S (n ++ n').
 
 Rewrite Rule addn0.
 Rewrite Rule addnS.
 Rewrite Rule add0n.
 Rewrite Rule addSn.
 
-Check eq_refl : 5 + 10 = 15.
+Check eq_refl : 5 ++ 10 = 15.
 Check (fun _ _ => eq_refl) : forall n n', S (S n) ++ S n' = S (S (S (n ++ n'))).
 Check (fun _ _ _ => eq_refl) : forall n n' n'', S (S n) ++ S n' ++ S (S n'') = S (S (S (S (S (n ++ n' ++ n''))))).
 
 Axiom raise : forall P: Type, P.
 
 Definition raise_bool := fun P p p' =>
-  match raise bool as b return P with
+  match raise bool as b return P b with
     true => p | false => p'
-  end == raise (let b := raise bool in P).
+  end ==> raise (P (raise bool)).
 
 Rewrite Rule raise_bool.
+
+Check eq_refl : match raise bool as b return true = b with true => eq_refl | false => raise _ end = raise (true = raise bool).
 
 Check eq_refl : match raise bool as b return b = b with true | false => eq_refl end = raise (let b := raise bool in b = b).

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -1,7 +1,7 @@
 Inductive rewrite {A : Type} (a: A) (b: A) := rewrite_intro.
 Notation "a ==> b" := (rewrite_intro a b) (at level 80).
 
-Axiom pplus : nat -> nat -> nat.
+Symbol pplus : nat -> nat -> nat.
 Notation "a ++ b" := (pplus a b).
 
 Definition addn0 := fun n => n ++ 0 ==> n.
@@ -18,7 +18,7 @@ Check eq_refl : 5 ++ 10 = 15.
 Check (fun _ _ => eq_refl) : forall n n', S (S n) ++ S n' = S (S (S (n ++ n'))).
 Check (fun _ _ _ => eq_refl) : forall n n' n'', S (S n) ++ S n' ++ S (S n'') = S (S (S (S (S (n ++ n' ++ n''))))).
 
-Axiom raise : forall P: Type, P.
+Symbol raise : forall P: Type, P.
 
 Definition raise_bool := fun P p p' =>
   match raise bool as b return P b with

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -29,4 +29,7 @@ Rewrite Rule raise_bool.
 
 Check eq_refl : match raise bool as b return true = b with true => eq_refl | false => raise _ end = raise (true = raise bool).
 
-Check eq_refl : match raise bool as b return b = b with true | false => eq_refl end = raise (let b := raise bool in b = b).
+Definition eq_diag {A} (x: A) := x = x.
+Check eq_refl : match raise bool as b return eq_diag b with true | false => eq_refl end = raise (raise bool = raise bool).
+
+Check eq_refl : match raise bool as b return b = b with true | false => eq_refl end = raise (raise bool = raise bool).

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -18,8 +18,8 @@ Rewrite Rule add0n.
 Rewrite Rule addSn.
 
 Check eq_refl : 5 ++ 10 = 15.
-Check (fun _ _ => eq_refl) : forall n n', S (S n) ++ S n' = S (S (S (n ++ n'))).
-Check (fun _ _ _ => eq_refl) : forall n n' n'', S (S n) ++ S n' ++ S (S n'') = S (S (S (S (S (n ++ n' ++ n''))))).
+Check (fun _ _ => eq_refl) : forall n n', 2 + n ++ 3 + n' = 5 + (n ++ n').
+Check (fun _ _ _ => eq_refl) : forall n n' n'', 2 + n ++ 1 + n' ++ 2 + n'' = 5 + (n ++ n' ++ n'').
 
 Symbol raise : forall P: Type, P.
 

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -5,3 +5,11 @@ Axiom symb_0 : symb = 0.
 Fail Rewrite Rule symb.
 
 Rewrite Rule symb_0.
+
+Definition symb' := Eval lazy in symb.
+Check eq_refl : symb' = 0.
+
+Check eq_refl : id symb = 0.
+
+(* bug: unfold_ref_with_args returns None from Rules *)
+Fail Check eq_refl : symb = 0.

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -1,0 +1,7 @@
+
+Axiom symb : nat.
+Axiom symb_0 : symb = 0.
+
+Fail Rewrite Rule symb.
+
+Rewrite Rule symb_0.

--- a/test-suite/success/rewrule.v
+++ b/test-suite/success/rewrule.v
@@ -1,15 +1,30 @@
+Inductive rewrite {A : Type} (a: A) (b: A) := rewrite_intro.
+Notation "a == b" := (rewrite_intro a b) (at level 80).
 
-Axiom symb : nat.
-Axiom symb_0 : symb = 0.
+Axiom pplus : nat -> nat -> nat.
+Notation "a ++ b" := (pplus a b).
 
-Fail Rewrite Rule symb.
+Definition addn0 := fun n => n ++ 0 == n.
+Definition addnS := fun n n' => n ++ S n' == S (n ++ n').
+Definition add0n := fun n => 0 ++ n == n.
+Definition addSn := fun n n' => S n ++ n' == S (n ++ n').
 
-Rewrite Rule symb_0.
+Rewrite Rule addn0.
+Rewrite Rule addnS.
+Rewrite Rule add0n.
+Rewrite Rule addSn.
 
-Definition symb' := Eval lazy in symb.
-Check eq_refl : symb' = 0.
+Check eq_refl : 5 + 10 = 15.
+Check (fun _ _ => eq_refl) : forall n n', S (S n) ++ S n' = S (S (S (n ++ n'))).
+Check (fun _ _ _ => eq_refl) : forall n n' n'', S (S n) ++ S n' ++ S (S n'') = S (S (S (S (S (n ++ n' ++ n''))))).
 
-Check eq_refl : id symb = 0.
+Axiom raise : forall P: Type, P.
 
-(* bug: unfold_ref_with_args returns None from Rules *)
-Fail Check eq_refl : symb = 0.
+Definition raise_bool := fun P p p' =>
+  match raise bool as b return P with
+    true => p | false => p'
+  end == raise (let b := raise bool in P).
+
+Rewrite Rule raise_bool.
+
+Check eq_refl : match raise bool as b return b = b with true | false => eq_refl end = raise (let b := raise bool in b = b).

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -199,7 +199,7 @@ let get_constant_body kn =
   let cb = lookup_constant kn in
   let access = Library.indirect_accessor in
   match cb.const_body with
-  | Undef _ | Primitive _ -> None
+  | Undef _ | Primitive _ | Symbol _ -> None
   | Def c -> Some c
   | OpaqueDef o ->
     match Global.force_proof access o with

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -277,6 +277,9 @@ let template =
   qualify_attribute ukey
     (bool_attribute ~name:"template")
 
+let unfold_fix =
+  enable_attribute ~key:"unfold_fix" ~default:(fun () -> false)
+
 let deprecation_parser : Deprecation.t key_parser = fun ?loc orig args ->
   assert_once ?loc ~name:"deprecation" orig;
   match args with

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -54,6 +54,7 @@ val raw_attributes : vernac_flags attribute
 val polymorphic : bool attribute
 val program : bool attribute
 val template : bool option attribute
+val unfold_fix : bool attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute
 val deprecation : Deprecation.t option attribute

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -34,7 +34,8 @@ let kind_searcher = Decls.(function
   | IsAssumption _
   | IsDefinition (Definition | Example | Fixpoint | CoFixpoint | Method | StructureComponent | Let)
   | IsProof _
-  | IsPrimitive as k -> Inl k
+  | IsPrimitive
+  | IsSymbol as k -> Inl k
   (* Kinds referring to the status of the object *)
   | IsDefinition (Coercion | SubClass | IdentityCoercion as k') ->
     let coercions = Coercionops.coercions () in

--- a/vernac/comSymbol.ml
+++ b/vernac/comSymbol.ml
@@ -1,0 +1,50 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+
+let declare id entry =
+  let _ : Constant.t =
+    Declare.declare_constant ~name:id ~kind:Decls.IsSymbol (Declare.SymbolEntry entry)
+  in
+  Flags.if_verbose Feedback.msg_info Pp.(Id.print id ++ str " is declared")
+
+let preprocess_symbols l =
+  let open Vernacexpr in
+  if Global.sections_are_opened () then
+    CErrors.user_err Pp.(str "Declaring a symbol is not allowed in sections.");
+  let no_udecl_msg = Pp.str "Symbols do not suport universe polymorphism." in
+  List.iter (fun (coe, (idl, c)) -> List.iter (function ({CAst.loc; _}, Some _) -> CErrors.user_err ?loc no_udecl_msg | (_, None) -> ()) idl) l;
+  let no_coercion_msg = Pp.(str "Cannot deal with coercions in symbols") in
+  List.iter (function AddCoercion, (({CAst.loc; _}, _) :: _, _) -> CErrors.user_err ?loc no_coercion_msg | AddCoercion, _ -> assert false | _ -> ()) l;
+  List.concat_map (fun (coe, (idl, c)) -> List.map (fun (id, _) -> id, c) idl) l
+
+let do_symbol (id, typ) =
+  if Dumpglob.dump () then Dumpglob.dump_definition id false "symb";
+  let id = id.CAst.v in
+  let env = Global.env () in
+  let evd = Evd.from_env env in
+  let evd, (typ, impls) =
+    Constrintern.(interp_type_evars_impls ~impls:empty_internalization_env)
+      env evd typ
+  in
+  Pretyping.check_evars_are_solved ~program_mode:false env evd;
+  let evd = Evd.minimize_universes evd in
+  let uvars = EConstr.universes_of_constr evd typ in
+  let evd = Evd.restrict_universe_context evd uvars in
+  let typ = EConstr.to_constr evd typ in
+  let univs = Evd.check_univ_decl ~poly:false evd UState.default_univ_decl in
+  let entry = Declare.symbol_entry ~univs typ in
+  declare id entry
+
+let do_symbols : (Constrexpr.ident_decl list * Constrexpr.constr_expr) Vernacexpr.with_coercion list -> unit =
+  fun l -> l
+  |> preprocess_symbols
+  |> List.iter do_symbol

--- a/vernac/comSymbol.ml
+++ b/vernac/comSymbol.ml
@@ -39,7 +39,7 @@ let preprocess_symbols l =
   List.iter (function AddCoercion, (({CAst.loc; _}, _) :: _, _) -> CErrors.user_err ?loc no_coercion_msg | AddCoercion, _ -> assert false | _ -> ()) l;
   udecl, List.concat_map (fun (coe, (idl, c)) -> List.map (fun (id, _) -> id, c) idl) l
 
-let do_symbol ~poly udecl (id, typ) =
+let do_symbol ~poly ~unfold_fix udecl (id, typ) =
   if Dumpglob.dump () then Dumpglob.dump_definition id false "symb";
   let id = id.CAst.v in
   let env = Global.env () in
@@ -54,9 +54,9 @@ let do_symbol ~poly udecl (id, typ) =
   let evd = Evd.restrict_universe_context evd uvars in
   let typ = EConstr.to_constr evd typ in
   let univs = Evd.check_univ_decl ~poly evd udecl in
-  let entry = Declare.symbol_entry ~univs typ in
+  let entry = Declare.symbol_entry ~univs ~unfold_fix typ in
   declare id entry
 
-let do_symbols ~poly l =
+let do_symbols ~poly ~unfold_fix l =
   let udecl, l = preprocess_symbols l in
-  List.iter (do_symbol ~poly udecl) l
+  List.iter (do_symbol ~poly ~unfold_fix udecl) l

--- a/vernac/comSymbol.ml
+++ b/vernac/comSymbol.ml
@@ -16,21 +16,34 @@ let declare id entry =
   in
   Flags.if_verbose Feedback.msg_info Pp.(Id.print id ++ str " is declared")
 
+let maybe_error_many_udecls = function
+| ({CAst.loc;v=id}, Some _) ->
+  CErrors.user_err ?loc
+    Pp.(strbrk "When declaring multiple symbols in one command, " ++
+        strbrk "only the first is allowed a universe binder " ++
+        strbrk "(which will be shared by the whole block).")
+| (_, None) -> ()
+
 let preprocess_symbols l =
   let open Vernacexpr in
   if Global.sections_are_opened () then
     CErrors.user_err Pp.(str "Declaring a symbol is not allowed in sections.");
-  let no_udecl_msg = Pp.str "Symbols do not suport universe polymorphism." in
-  List.iter (fun (coe, (idl, c)) -> List.iter (function ({CAst.loc; _}, Some _) -> CErrors.user_err ?loc no_udecl_msg | (_, None) -> ()) idl) l;
+  let udecl = match l with
+    | (coe, ((id, udecl)::rest, c))::rest' ->
+      List.iter maybe_error_many_udecls rest;
+      List.iter (fun (coe, (idl, c)) -> List.iter maybe_error_many_udecls idl) rest';
+      udecl
+    | (_, ([], _))::_ | [] -> assert false
+  in
   let no_coercion_msg = Pp.(str "Cannot deal with coercions in symbols") in
   List.iter (function AddCoercion, (({CAst.loc; _}, _) :: _, _) -> CErrors.user_err ?loc no_coercion_msg | AddCoercion, _ -> assert false | _ -> ()) l;
-  List.concat_map (fun (coe, (idl, c)) -> List.map (fun (id, _) -> id, c) idl) l
+  udecl, List.concat_map (fun (coe, (idl, c)) -> List.map (fun (id, _) -> id, c) idl) l
 
-let do_symbol (id, typ) =
+let do_symbol ~poly udecl (id, typ) =
   if Dumpglob.dump () then Dumpglob.dump_definition id false "symb";
   let id = id.CAst.v in
   let env = Global.env () in
-  let evd = Evd.from_env env in
+  let evd, udecl = Constrintern.interp_univ_decl_opt env udecl in
   let evd, (typ, impls) =
     Constrintern.(interp_type_evars_impls ~impls:empty_internalization_env)
       env evd typ
@@ -40,11 +53,10 @@ let do_symbol (id, typ) =
   let uvars = EConstr.universes_of_constr evd typ in
   let evd = Evd.restrict_universe_context evd uvars in
   let typ = EConstr.to_constr evd typ in
-  let univs = Evd.check_univ_decl ~poly:false evd UState.default_univ_decl in
+  let univs = Evd.check_univ_decl ~poly evd udecl in
   let entry = Declare.symbol_entry ~univs typ in
   declare id entry
 
-let do_symbols : (Constrexpr.ident_decl list * Constrexpr.constr_expr) Vernacexpr.with_coercion list -> unit =
-  fun l -> l
-  |> preprocess_symbols
-  |> List.iter do_symbol
+let do_symbols ~poly l =
+  let udecl, l = preprocess_symbols l in
+  List.iter (do_symbol ~poly udecl) l

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -125,6 +125,7 @@ type primitive_entry = {
 
 type symbol_entry = {
   symb_entry_type : Constr.types;
+  symb_entry_unfold_fix: bool;
   symb_entry_universes : UState.named_universes_entry;
 }
 
@@ -158,8 +159,9 @@ let primitive_entry ?types c = {
   prim_entry_content = c;
 }
 
-let symbol_entry ?(univs=default_named_univ_entry) symb_entry_type = {
+let symbol_entry ?(univs=default_named_univ_entry) ~unfold_fix symb_entry_type = {
   symb_entry_universes = univs;
+  symb_entry_unfold_fix = unfold_fix;
   symb_entry_type;
 }
 
@@ -432,11 +434,12 @@ let declare_constant_core ~name ~typing_flags cd =
       } in
       let ubinders = (UState.Monomorphic_entry ctx, ubinders) in
       ConstantEntry (Entries.PrimitiveEntry e), false, ubinders, None
-    | SymbolEntry { symb_entry_type=typ; symb_entry_universes=(univs, ubinders) } ->
+    | SymbolEntry { symb_entry_type=typ; symb_entry_unfold_fix=un_fix; symb_entry_universes=(univs, ubinders) } ->
       let univ_entry, ctx = extract_monomorphic univs in
       let () = DeclareUctx.declare_universe_context ~poly:false ctx in
       let e = {
         Entries.symb_entry_type = typ;
+        Entries.symb_entry_unfold_fix = un_fix;
         Entries.symb_entry_universes = univ_entry;
       } in
       let ubinders = (UState.Monomorphic_entry ctx, ubinders) in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -345,6 +345,7 @@ val primitive_entry
 
 val symbol_entry
   :  ?univs:UState.named_universes_entry
+  -> unfold_fix:bool
   -> Constr.types
   -> symbol_entry
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -321,6 +321,7 @@ end
 type proof_entry
 type parameter_entry
 type primitive_entry
+type symbol_entry
 
 val definition_entry
   :  ?opaque:bool
@@ -341,6 +342,11 @@ val primitive_entry
   :  ?types:(Constr.types * UState.named_universes_entry)
   -> CPrimitives.op_or_type
   -> primitive_entry
+
+val symbol_entry
+  :  ?univs:UState.named_universes_entry
+  -> Constr.types
+  -> symbol_entry
 
 (** XXX: This is an internal, low-level API and could become scheduled
     for removal from the public API, use higher-level declare APIs
@@ -374,6 +380,7 @@ type constant_entry =
   | DefinitionEntry of proof_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
+  | SymbolEntry of symbol_entry
 
 val prepare_parameter
   : poly:bool

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -227,6 +227,11 @@ GRAMMAR EXTEND Gram
             VernacAssumption (stre, nl, bl) }
       | d = def_token; id = ident_decl; b = def_body ->
           { VernacDefinition (d, name_of_ident_decl id, b) }
+      | IDENT "Symbol"; bl = assum_list ->
+          { VernacSymbol bl }
+      | IDENT "Symbols"; bl = assum_list ->
+          { test_plural_form loc "Symbols" bl;
+            VernacSymbol bl }
       | IDENT "Let"; id = ident_decl; b = def_body ->
           { VernacDefinition ((DoDischarge, Let), name_of_ident_decl id, b) }
       (* Gallina inductive declarations *)
@@ -1135,7 +1140,8 @@ GRAMMAR EXTEND Gram
       | k = assumption_token -> { IsAssumption (snd k) }
       | k = IDENT "Context" -> { IsAssumption Context }
       | k = extended_def_token -> { IsDefinition k }
-      | IDENT "Primitive" -> { IsPrimitive } ] ]
+      | IDENT "Primitive" -> { IsPrimitive }
+      | IDENT "Symbol" -> { IsSymbol } ] ]
   ;
   extended_def_token:
     [ [ k = def_token -> { snd k }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -258,6 +258,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Universe"; l = LIST1 identref -> { VernacUniverse l }
       | IDENT "Universes"; l = LIST1 identref -> { VernacUniverse l }
       | IDENT "Constraint"; l = LIST1 univ_constraint SEP "," -> { VernacConstraint l }
+      | IDENT "Rewrite"; IDENT "Rule"; c = smart_global ->
+        { VernacAddRewRule c }
   ] ]
   ;
   register_token:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -181,6 +181,7 @@ let string_of_logical_kind = let open Decls in function
     | IsDefinition k -> string_of_definition_object_kind k
     | IsProof k -> string_of_theorem_kind k
     | IsPrimitive -> "Primitive"
+    | IsSymbol -> "Symbol"
 
 let pr_notation_entry = function
   | InConstrEntry -> keyword "constr"
@@ -867,6 +868,13 @@ let pr_vernac_expr v =
     let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
     return (hov 2 (pr_assumption_token (n > 1) discharge kind ++
                    pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
+  | VernacSymbol l ->
+    let n = List.length (List.flatten (List.map fst (List.map snd l))) in
+    let pr_params (c, (xl, t)) =
+      hov 2 (prlist_with_sep sep pr_ident_decl xl ++ spc() ++
+              str(match c with AddCoercion -> ":>" | NoCoercion -> ":") ++ spc() ++ pr_lconstr_expr t) in
+    let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
+    return (hov 2 (keyword (if (n > 1) then "Symbols" else "Symbol") ++ spc() ++ assumptions))
   | VernacInductive (f,l) ->
     let pr_constructor ((coe,ins),(id,c)) =
       hov 2 (pr_lident id ++ pr_oc coe ins ++

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1352,6 +1352,8 @@ let pr_vernac_expr v =
   | VernacEndSubproof ->
     return (str "}")
 
+  | VernacAddRewRule c -> return (keyword "Rewrite Rule" ++ spc() ++ pr_smart_global c)
+
 let pr_control_flag (p : control_flag) =
   let w = match p with
     | ControlTime _ -> keyword "Time"

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -172,7 +172,7 @@ let opacity env =
   | GlobRef.ConstRef cst ->
       let cb = Environ.lookup_constant cst env in
       (match cb.const_body with
-        | Undef _ | Primitive _ -> None
+        | Undef _ | Primitive _ | Symbol _ -> None
         | OpaqueDef _ -> Some FullyOpaque
         | Def _ -> Some
           (TransparentMaybeOpacified
@@ -862,6 +862,9 @@ let print_full_pure_atomic env sigma mp lobj =
           pr_lconstr_env env sigma c
         | Primitive _ ->
           str "Primitive " ++
+          print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ
+        | Symbol _ ->
+          str "Symbol " ++
           print_basename con ++ str " :" ++ spc () ++ pr_ltype_env env sigma typ)
       ++ str "." ++ fnl () ++ fnl ()
     end @@

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -154,6 +154,7 @@ let classify_vernac e =
     | VernacComments _
     | VernacSchemeEquality _
     | VernacDeclareInstance _
+    | VernacAddRewRule _
     | VernacExtraDependency _ -> VtSideff ([], VtLater)
     (* Who knows *)
     | VernacLoad _ -> VtSideff ([], VtNow)

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -118,6 +118,9 @@ let classify_vernac e =
     | VernacAssumption (_,_,l) ->
         let ids = List.flatten (List.map (fun (_,(l,_)) -> List.map (fun (id, _) -> id.v) l) l) in
         VtSideff (ids, VtLater)
+    | VernacSymbol l ->
+        let ids = List.flatten (List.map (fun (_,(l,_)) -> List.map (fun (id, _) -> id.v) l) l) in
+        VtSideff (ids, VtLater)
     | VernacPrimitive ((id,_),_,_) ->
         VtSideff ([id.CAst.v], VtLater)
     | VernacDefinition (_,({v=id},_),DefineBody _) -> VtSideff (idents_of_name id, VtLater)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2443,6 +2443,10 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
         vernac_declare_module_type lid bl mtys mtyo)
   | VernacAssumption ((discharge,kind),nl,l) ->
     vtdefault(fun () -> with_def_attributes ~atts vernac_assumption discharge kind l nl)
+  | VernacSymbol l ->
+    vtdefault (fun () ->
+        unsupported_attributes atts;
+        ComSymbol.do_symbols l)
   | VernacInductive (finite, l) ->
     vtdefault(fun () -> vernac_inductive ~atts finite l)
   | VernacFixpoint (discharge, l) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1151,6 +1151,13 @@ let vernac_constraint ~poly l =
                   ++ str " inside sections, use Monomorphic Constraint instead.");
   DeclareUniv.do_constraint ~poly l
 
+let vernac_add_rew_rule c =
+  let gr = smart_global c in
+  match gr with
+  | IndRef _ | VarRef _ | ConstructRef _ ->
+    user_err ?loc:c.loc Pp.(str "Rewrite Rule must be used on a constant.")
+  | ConstRef c -> Global.add_rewrite_rule c
+
 (**********************)
 (* Modules            *)
 
@@ -2469,6 +2476,11 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () -> vernac_universe ~poly:(only_polymorphism atts) l)
   | VernacConstraint l ->
     vtdefault(fun () -> vernac_constraint ~poly:(only_polymorphism atts) l)
+
+  | VernacAddRewRule c ->
+    vtdefault (fun () ->
+        unsupported_attributes atts;
+        vernac_add_rew_rule c)
 
   (* Modules *)
   | VernacDeclareModule (export,lid,bl,mtyo) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2445,8 +2445,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () -> with_def_attributes ~atts vernac_assumption discharge kind l nl)
   | VernacSymbol l ->
     vtdefault (fun () ->
-        unsupported_attributes atts;
-        ComSymbol.do_symbols l)
+        ComSymbol.do_symbols ~poly:(only_polymorphism atts) l)
   | VernacInductive (finite, l) ->
     vtdefault(fun () -> vernac_inductive ~atts finite l)
   | VernacFixpoint (discharge, l) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2445,7 +2445,10 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     vtdefault(fun () -> with_def_attributes ~atts vernac_assumption discharge kind l nl)
   | VernacSymbol l ->
     vtdefault (fun () ->
-        ComSymbol.do_symbols ~poly:(only_polymorphism atts) l)
+      let unfold_fix, poly =
+      Attributes.(parse Notations.(unfold_fix ++ polymorphic)) atts
+      in
+        ComSymbol.do_symbols ~poly ~unfold_fix l)
   | VernacInductive (finite, l) ->
     vtdefault(fun () -> vernac_inductive ~atts finite l)
   | VernacFixpoint (discharge, l) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -371,6 +371,7 @@ type nonrec vernac_expr =
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list
   | VernacConstraint of univ_constraint_expr list
+  | VernacAddRewRule of qualid or_by_notation
 
   (* Gallina extensions *)
   | VernacBeginSection of lident

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -363,6 +363,7 @@ type nonrec vernac_expr =
   | VernacExactProof of constr_expr
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
+  | VernacSymbol of (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of inductive_kind * (inductive_expr * notation_declaration list) list
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list


### PR DESCRIPTION
The aim of this PR is to add support for non-linear rules such as
`cast A A e t ==> t`
which should fire whenever the symbol `cast` is applied to arguments `A, B, e t` such that `A` and `B` are convertible.

My suggestion is to modify the `rewrite_rule` type to add a field `lhs_eqs` that records equations between the hole indices of the left-hand side. Then, in the reduction phase, we want to check for convertibility while we are filling pattern holes, and kill any pattern that does not respect an equation.

The changes in the reduction machines is still work in progress for now.